### PR TITLE
fix missing conf that cause docker startup to fail

### DIFF
--- a/example/apisix_conf/config.yaml
+++ b/example/apisix_conf/config.yaml
@@ -83,7 +83,9 @@ apisix:
 nginx_config:                     # config for render the template to genarate nginx.conf
   error_log: "logs/error.log"
   error_log_level: "warn"         # warn,error
+  worker_processes: auto
   worker_rlimit_nofile: 20480     # the number of files a worker process can open, should be larger than worker_connections
+  worker_shutdown_timeout: 240s     # timeout for a graceful shutdown of worker processes
   event:
     worker_connections: 10620
   http:


### PR DESCRIPTION
Related to: https://github.com/apache/apisix-docker/issues/69