### PR TITLE
fix: use the code from master branch to build dashboard image

### DIFF
--- a/all-in-one/apisix-dashboard/Dockerfile
+++ b/all-in-one/apisix-dashboard/Dockerfile
@@ -33,7 +33,7 @@ RUN wget https://github.com/etcd-io/etcd/releases/download/${ETCD_VERSION}/etcd-
 
 FROM alpine:latest as pre-build
 
-ARG APISIX_DASHBOARD_VERSION=v2.0
+ARG APISIX_DASHBOARD_VERSION=master
 
 RUN set -x \
     && wget https://github.com/apache/apisix-dashboard/archive/${APISIX_DASHBOARD_VERSION}.tar.gz -O /tmp/apisix-dashboard.tar.gz \


### PR DESCRIPTION
Signed-off-by: imjoey <majunjiev@gmail.com>

Related to issue https://github.com/apache/apisix-dashboard/issues/1145 .

This PR is going to set the variable `APISIX_DASHBOARD_VERSION` to `master`, and then we can use the latest code from master branch, instead of a specified release version. This is similar to PR https://github.com/apache/apisix-dashboard/pull/1146 which would fix the one within `apache/apisix-dashboard` repo. Thanks.