### PR TITLE
feat: Support ENABLE_PROXY argument at building phrase for mirror switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ export APISIX_VERSION=master
 docker build -t apisix:${APISIX_VERSION}-alpine --build-arg APISIX_VERSION=${APISIX_VERSION} -f alpine/Dockerfile alpine
 ```
 
-> Note: For Chinese users, building the image with the build argument `ENABLE_PROXY=true` is always recommended to accelerate the progress.
+> Note: For Chinese users, the following command `docker build -t apisix:${APISIX_VERSION}-alpine --build-arg APISIX_VERSION=${APISIX_VERSION} --build-arg ENABLE_PROXY=true -f alpine/Dockerfile alpine` is always recommended. The additional build argument `ENABLE_PROXY=true` will enable proxy to definitely accelerate the progress.
 
 ### Manual deploy apisix via docker
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ export APISIX_VERSION=master
 docker build -t apisix:${APISIX_VERSION}-alpine --build-arg APISIX_VERSION=${APISIX_VERSION} -f alpine/Dockerfile alpine
 ```
 
+> Note: For Chinese users, building the image with the build argument `ENABLE_PROXY=true` is always recommended to accelerate the progress.
+
 ### Manual deploy apisix via docker
 
 [Manual deploy](manual.md)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@ export APISIX_VERSION=master
 docker build -t apisix:${APISIX_VERSION}-alpine --build-arg APISIX_VERSION=${APISIX_VERSION} -f alpine/Dockerfile alpine
 ```
 
-> Note: For Chinese users, the following command `docker build -t apisix:${APISIX_VERSION}-alpine --build-arg APISIX_VERSION=${APISIX_VERSION} --build-arg ENABLE_PROXY=true -f alpine/Dockerfile alpine` is always recommended. The additional build argument `ENABLE_PROXY=true` will enable proxy to definitely accelerate the progress.
+**Note:** For Chinese, the following command is always recommended. The additional build argument `ENABLE_PROXY=true` will enable proxy to definitely accelerate the progress.
+
+```sh
+$ docker build -t apisix:${APISIX_VERSION}-alpine --build-arg APISIX_VERSION=${APISIX_VERSION} --build-arg ENABLE_PROXY=true -f alpine/Dockerfile alpine
 
 ### Manual deploy apisix via docker
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ docker build -t apisix:${APISIX_VERSION}-alpine --build-arg APISIX_VERSION=${API
 
 ```sh
 $ docker build -t apisix:${APISIX_VERSION}-alpine --build-arg APISIX_VERSION=${APISIX_VERSION} --build-arg ENABLE_PROXY=true -f alpine/Dockerfile alpine
+```
 
 ### Manual deploy apisix via docker
 

--- a/all-in-one/apisix-dashboard/Dockerfile
+++ b/all-in-one/apisix-dashboard/Dockerfile
@@ -1,11 +1,13 @@
+ARG ENABLE_PROXY=false
+
 FROM openresty/openresty:alpine-fat AS production-stage
 
 ARG APISIX_VERSION=master
 LABEL apisix_version="${APISIX_VERSION}"
 
-
+ARG ENABLE_PROXY
 RUN set -x \
-    && /bin/sed -i 's,http://dl-cdn.alpinelinux.org,https://mirrors.aliyun.com,g' /etc/apk/repositories \
+    && (test "${ENABLE_PROXY}" != "true" || /bin/sed -i 's,http://dl-cdn.alpinelinux.org,https://mirrors.aliyun.com,g' /etc/apk/repositories) \
     && apk add --no-cache --virtual .builddeps \
     automake \
     autoconf \
@@ -42,7 +44,7 @@ RUN set -x \
 
 FROM golang:1.14 as api-builder
 
-ARG ENABLE_PROXY=false
+ARG ENABLE_PROXY
 ARG APISIX_DASHBOARD_VERSION=master
 
 WORKDIR /usr/local/apisix-dashboard
@@ -84,9 +86,10 @@ RUN yarn build
 
 FROM alpine:3.11 AS last-stage
 
+ARG ENABLE_PROXY
 # add runtime for Apache APISIX
 RUN set -x \
-    && /bin/sed -i 's,http://dl-cdn.alpinelinux.org,https://mirrors.aliyun.com,g' /etc/apk/repositories \
+    && (test "${ENABLE_PROXY}" != "true" || /bin/sed -i 's,http://dl-cdn.alpinelinux.org,https://mirrors.aliyun.com,g' /etc/apk/repositories) \
     && apk add --no-cache bash libstdc++ curl
 
 WORKDIR /usr/local/apisix
@@ -101,8 +104,6 @@ COPY --from=etcd-stage /tmp/etcd/etcdctl /usr/bin/etcdctl
 ENV PATH=$PATH:/usr/local/openresty/luajit/bin:/usr/local/openresty/nginx/sbin:/usr/local/openresty/bin
 
 # dashboard
-
-ARG ENABLE_PROXY=false
 
 RUN if [ "$ENABLE_PROXY" = "true" ] ; then sed -i 's/dl-cdn.alpinelinux.org/mirrors.ustc.edu.cn/g' /etc/apk/repositories ; fi
 

--- a/all-in-one/apisix-dashboard/Dockerfile
+++ b/all-in-one/apisix-dashboard/Dockerfile
@@ -22,16 +22,17 @@ RUN set -x \
     && mv /usr/local/apisix/deps/share/lua/5.1/apisix /usr/local/apisix \
     && apk del .builddeps build-base make unzip
 
+
 FROM alpine:3.11 AS etcd-stage
 
 ARG ETCD_VERSION=v3.4.14
 LABEL etcd_version="${ETCD_VERSION}"
 
 WORKDIR /tmp
-
 RUN wget https://github.com/etcd-io/etcd/releases/download/${ETCD_VERSION}/etcd-${ETCD_VERSION}-linux-amd64.tar.gz \
     && tar -zxvf etcd-${ETCD_VERSION}-linux-amd64.tar.gz \
     && ln -s etcd-${ETCD_VERSION}-linux-amd64 etcd
+
 
 FROM alpine:latest as pre-build
 
@@ -41,6 +42,7 @@ RUN set -x \
     && wget https://github.com/apache/apisix-dashboard/archive/${APISIX_DASHBOARD_VERSION}.tar.gz -O /tmp/apisix-dashboard.tar.gz \
     && mkdir /usr/local/apisix-dashboard \
     && tar -xvf /tmp/apisix-dashboard.tar.gz -C /usr/local/apisix-dashboard --strip 1
+
 
 FROM golang:1.14 as api-builder
 
@@ -54,18 +56,16 @@ COPY --from=pre-build /usr/local/apisix-dashboard .
 WORKDIR /usr/local/apisix-dashboard/api
 
 RUN mkdir -p ../output/conf \
-    && cp ./conf/*.json ../output/conf
-
-RUN wget https://github.com/api7/dag-to-lua/archive/v1.1.tar.gz -O /tmp/v1.1.tar.gz \
+    && cp ./conf/*.json ../output/conf \
+    && wget https://github.com/api7/dag-to-lua/archive/v1.1.tar.gz -O /tmp/v1.1.tar.gz \
     && mkdir /tmp/dag-to-lua \
     && tar -xvf /tmp/v1.1.tar.gz -C /tmp/dag-to-lua --strip 1 \
     && mkdir -p ../output/dag-to-lua \
-    && mv /tmp/dag-to-lua/lib/* ../output/dag-to-lua/
-
-RUN if [ "$ENABLE_PROXY" = "true" ] ; then go env -w GOPROXY=https://goproxy.io,direct ; fi
-
-RUN go env -w GO111MODULE=on \
+    && mv /tmp/dag-to-lua/lib/* ../output/dag-to-lua/ \
+    && if [ "$ENABLE_PROXY" = "true" ] ; then go env -w GOPROXY=https://goproxy.io,direct ; fi \
+    && go env -w GO111MODULE=on \
     && if [ "$APISIX_DASHBOARD_VERSION" = "master" ] || [ "$APISIX_DASHBOARD_VERSION" \> "v2.2" ]; then CGO_ENABLED=0 go build -o ../output/manager-api ./cmd/manager; else CGO_ENABLED=0 go build -o ../output/manager-api . ; fi;
+
 
 FROM node:14-alpine as fe-builder
 
@@ -77,11 +77,9 @@ COPY --from=pre-build /usr/local/apisix-dashboard .
 
 WORKDIR /usr/local/apisix-dashboard/web
 
-RUN if [ "$ENABLE_PROXY" = "true" ] ; then yarn config set registry https://registry.npm.taobao.org/ ; fi
-
-RUN yarn install
-
-RUN yarn build
+RUN if [ "$ENABLE_PROXY" = "true" ] ; then yarn config set registry https://registry.npm.taobao.org/ ; fi \
+    && yarn install \
+    && yarn build
 
 
 FROM alpine:3.11 AS last-stage
@@ -105,14 +103,12 @@ ENV PATH=$PATH:/usr/local/openresty/luajit/bin:/usr/local/openresty/nginx/sbin:/
 
 # dashboard
 
-RUN if [ "$ENABLE_PROXY" = "true" ] ; then sed -i 's/dl-cdn.alpinelinux.org/mirrors.ustc.edu.cn/g' /etc/apk/repositories ; fi
-
-RUN apk add lua5.1
+RUN if [ "$ENABLE_PROXY" = "true" ] ; then sed -i 's/dl-cdn.alpinelinux.org/mirrors.ustc.edu.cn/g' /etc/apk/repositories ; fi \
+    && apk add lua5.1
 
 WORKDIR /usr/local/apisix-dashboard
 
 COPY --from=api-builder /usr/local/apisix-dashboard/output/ ./
-
 COPY --from=fe-builder /usr/local/apisix-dashboard/output/ ./
 
 RUN mkdir logs

--- a/all-in-one/apisix/Dockerfile
+++ b/all-in-one/apisix/Dockerfile
@@ -1,11 +1,13 @@
+ARG ENABLE_PROXY=false
+
 FROM openresty/openresty:alpine-fat AS production-stage
 
 ARG APISIX_VERSION=master
 LABEL apisix_version="${APISIX_VERSION}"
 
-
+ARG ENABLE_PROXY
 RUN set -x \
-    && /bin/sed -i 's,http://dl-cdn.alpinelinux.org,https://mirrors.aliyun.com,g' /etc/apk/repositories \
+    && (test "${ENABLE_PROXY}" != "true" || /bin/sed -i 's,http://dl-cdn.alpinelinux.org,https://mirrors.aliyun.com,g' /etc/apk/repositories) \
     && apk add --no-cache --virtual .builddeps \
     automake \
     autoconf \
@@ -33,9 +35,10 @@ RUN wget https://github.com/etcd-io/etcd/releases/download/${ETCD_VERSION}/etcd-
 
 FROM alpine:3.11 AS last-stage
 
+ARG ENABLE_PROXY
 # add runtime for Apache APISIX
 RUN set -x \
-    && /bin/sed -i 's,http://dl-cdn.alpinelinux.org,https://mirrors.aliyun.com,g' /etc/apk/repositories \
+    && (test "${ENABLE_PROXY}" != "true" || /bin/sed -i 's,http://dl-cdn.alpinelinux.org,https://mirrors.aliyun.com,g' /etc/apk/repositories) \
     && apk add --no-cache bash libstdc++ curl
 
 WORKDIR /usr/local/apisix

--- a/alpine-dev/Dockerfile
+++ b/alpine-dev/Dockerfile
@@ -1,7 +1,10 @@
+ARG ENABLE_PROXY=false
+
 FROM openresty/openresty:alpine-fat AS production-stage
 
+ARG ENABLE_PROXY
 RUN set -x \
-    && /bin/sed -i 's,http://dl-cdn.alpinelinux.org,https://mirrors.aliyun.com,g' /etc/apk/repositories \
+    && (test "${ENABLE_PROXY}" != "true" || /bin/sed -i 's,http://dl-cdn.alpinelinux.org,https://mirrors.aliyun.com,g' /etc/apk/repositories) \
     && apk add --no-cache --virtual .builddeps \
     automake \
     autoconf \
@@ -18,9 +21,10 @@ RUN set -x \
 
 FROM alpine:3.11 AS last-stage
 
+ARG ENABLE_PROXY
 # add runtime for Apache APISIX
 RUN set -x \
-    && /bin/sed -i 's,http://dl-cdn.alpinelinux.org,https://mirrors.aliyun.com,g' /etc/apk/repositories \
+    && (test "${ENABLE_PROXY}" != "true" || /bin/sed -i 's,http://dl-cdn.alpinelinux.org,https://mirrors.aliyun.com,g' /etc/apk/repositories) \
     && apk add --no-cache bash libstdc++ curl
 
 WORKDIR /usr/local/apisix

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,10 +1,13 @@
+ARG ENABLE_PROXY=false
+
 FROM openresty/openresty:alpine-fat AS production-stage
 
 ARG APISIX_VERSION=1.3
 LABEL apisix_version="${APISIX_VERSION}"
 
+ARG ENABLE_PROXY
 RUN set -x \
-    && /bin/sed -i 's,http://dl-cdn.alpinelinux.org,https://mirrors.aliyun.com,g' /etc/apk/repositories \
+    && (test "${ENABLE_PROXY}" != "true" || /bin/sed -i 's,http://dl-cdn.alpinelinux.org,https://mirrors.aliyun.com,g' /etc/apk/repositories) \
     && apk add --no-cache --virtual .builddeps \
     automake \
     autoconf \
@@ -21,9 +24,10 @@ RUN set -x \
 
 FROM alpine:3.11 AS last-stage
 
+ARG ENABLE_PROXY
 # add runtime for Apache APISIX
 RUN set -x \
-    && /bin/sed -i 's,http://dl-cdn.alpinelinux.org,https://mirrors.aliyun.com,g' /etc/apk/repositories \
+    && (test "${ENABLE_PROXY}" != "true" || /bin/sed -i 's,http://dl-cdn.alpinelinux.org,https://mirrors.aliyun.com,g' /etc/apk/repositories) \
     && apk add --no-cache bash libstdc++ curl
 
 WORKDIR /usr/local/apisix


### PR DESCRIPTION
Previously, the `aliyun` mirror is always used in docker build phrase and it's honestly not properly set for non-Chinese users.

Changes proposed in this PR:

- Introduce a new build argument `ENABLE_PROXY` in Dockerfile for APISIX, building will use proxy if `ENABLE_PROXY` is set to `true`
- Add guides for the new `ENABLE_PROXY`
- Reduce the count of individual `RUN` commands in Dockerfile for Dashboard to reduce the image size as well as the build time cost
- Make Dockerfile be more conventional via some other minor changes


