### PR TITLE
fix: modify dockerfile  when apisix version > 2.2

### DIFF
--- a/.github/workflows/linux_alpine_ci.yaml
+++ b/.github/workflows/linux_alpine_ci.yaml
@@ -12,4 +12,4 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: use docker-compose
-      run: cd ./example && sudo docker-compose -f docker-compose-alpine.yml -p docker-apisix up -d
+      run: cd ./example && docker-compose -f docker-compose-alpine.yml -p docker-apisix up -d

--- a/.github/workflows/linux_alpine_ci.yaml
+++ b/.github/workflows/linux_alpine_ci.yaml
@@ -1,4 +1,4 @@
-name: Docker compose CI on linux
+name: Docker compose alpine CI on linux
 
 on:
   push:

--- a/.github/workflows/linux_alpine_ci.yaml
+++ b/.github/workflows/linux_alpine_ci.yaml
@@ -12,4 +12,4 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: use docker-compose
-      run: cd ./example && docker-compose -f docker-compose-alpine.yml -p docker-apisix up -d
+      run: cd ./example && sudo docker-compose -f docker-compose-alpine.yml -p docker-apisix up -d

--- a/all-in-one/apisix-dashboard/Dockerfile
+++ b/all-in-one/apisix-dashboard/Dockerfile
@@ -19,8 +19,8 @@ RUN set -x \
     pkgconfig \
     cmake \
     git \
-    && sudo luarocks config variables.OPENSSL_LIBDIR /usr/local/openresty/openssl/lib \
-    && sudo luarocks config variables.OPENSSL_INCDIR /usr/local/openresty/openssl/include \
+    && luarocks config variables.OPENSSL_LIBDIR /usr/local/openresty/openssl/lib \
+    && luarocks config variables.OPENSSL_INCDIR /usr/local/openresty/openssl/include \
     && luarocks install https://github.com/apache/apisix/raw/master/rockspec/apisix-${APISIX_VERSION}-0.rockspec --tree=/usr/local/apisix/deps \
     && cp -v /usr/local/apisix/deps/lib/luarocks/rocks-5.1/apisix/${APISIX_VERSION}-0/bin/apisix /usr/bin/ \
     && (if [ "$APISIX_VERSION" = "master" ] || [ "$APISIX_VERSION" \> "2.2" ]; then echo 'use shell ';else bin='#! /usr/local/openresty/luajit/bin/luajit\npackage.path = "/usr/local/apisix/?.lua;" .. package.path'; sed -i "1s@.*@$bin@" /usr/bin/apisix ; fi;) \

--- a/all-in-one/apisix-dashboard/Dockerfile
+++ b/all-in-one/apisix-dashboard/Dockerfile
@@ -19,6 +19,7 @@ RUN set -x \
     pkgconfig \
     cmake \
     git \
+    && mkdir ~/.luarocks \
     && luarocks config variables.OPENSSL_LIBDIR /usr/local/openresty/openssl/lib \
     && luarocks config variables.OPENSSL_INCDIR /usr/local/openresty/openssl/include \
     && luarocks install https://github.com/apache/apisix/raw/master/rockspec/apisix-${APISIX_VERSION}-0.rockspec --tree=/usr/local/apisix/deps \

--- a/all-in-one/apisix-dashboard/Dockerfile
+++ b/all-in-one/apisix-dashboard/Dockerfile
@@ -23,8 +23,7 @@ RUN set -x \
     && luarocks config variables.OPENSSL_INCDIR /usr/local/openresty/openssl/include \
     && luarocks install https://github.com/apache/apisix/raw/master/rockspec/apisix-${APISIX_VERSION}-0.rockspec --tree=/usr/local/apisix/deps \
     && cp -v /usr/local/apisix/deps/lib/luarocks/rocks-5.1/apisix/${APISIX_VERSION}-0/bin/apisix /usr/bin/ \
-    && bin='#! /usr/local/openresty/luajit/bin/luajit\npackage.path = "/usr/local/apisix/?.lua;" .. package.path' \
-    && sed -i "1s@.*@$bin@" /usr/bin/apisix \
+    && (if [ "$APISIX_VERSION" = "master" ] || [ "$APISIX_VERSION" \> "2.2" ]; then echo 'use shell ';else bin='#! /usr/local/openresty/luajit/bin/luajit\npackage.path = "/usr/local/apisix/?.lua;" .. package.path'; sed -i "1s@.*@$bin@" /usr/bin/apisix ; fi;) \
     && mv /usr/local/apisix/deps/share/lua/5.1/apisix /usr/local/apisix \
     && apk del .builddeps build-base make unzip
 

--- a/all-in-one/apisix-dashboard/Dockerfile
+++ b/all-in-one/apisix-dashboard/Dockerfile
@@ -19,8 +19,8 @@ RUN set -x \
     pkgconfig \
     cmake \
     git \
-    && luarocks config variables.OPENSSL_LIBDIR /usr/local/openresty/openssl/lib \
-    && luarocks config variables.OPENSSL_INCDIR /usr/local/openresty/openssl/include \
+    && sudo luarocks config variables.OPENSSL_LIBDIR /usr/local/openresty/openssl/lib \
+    && sudo luarocks config variables.OPENSSL_INCDIR /usr/local/openresty/openssl/include \
     && luarocks install https://github.com/apache/apisix/raw/master/rockspec/apisix-${APISIX_VERSION}-0.rockspec --tree=/usr/local/apisix/deps \
     && cp -v /usr/local/apisix/deps/lib/luarocks/rocks-5.1/apisix/${APISIX_VERSION}-0/bin/apisix /usr/bin/ \
     && (if [ "$APISIX_VERSION" = "master" ] || [ "$APISIX_VERSION" \> "2.2" ]; then echo 'use shell ';else bin='#! /usr/local/openresty/luajit/bin/luajit\npackage.path = "/usr/local/apisix/?.lua;" .. package.path'; sed -i "1s@.*@$bin@" /usr/bin/apisix ; fi;) \

--- a/all-in-one/apisix/Dockerfile
+++ b/all-in-one/apisix/Dockerfile
@@ -19,8 +19,8 @@ RUN set -x \
     pkgconfig \
     cmake \
     git \
-    && sudo luarocks config variables.OPENSSL_LIBDIR /usr/local/openresty/openssl/lib \
-    && sudo luarocks config variables.OPENSSL_INCDIR /usr/local/openresty/openssl/include \
+    && luarocks config variables.OPENSSL_LIBDIR /usr/local/openresty/openssl/lib \
+    && luarocks config variables.OPENSSL_INCDIR /usr/local/openresty/openssl/include \
     && luarocks install https://github.com/apache/apisix/raw/master/rockspec/apisix-${APISIX_VERSION}-0.rockspec --tree=/usr/local/apisix/deps \
     && cp -v /usr/local/apisix/deps/lib/luarocks/rocks-5.1/apisix/${APISIX_VERSION}-0/bin/apisix /usr/bin/ \
     && (if [ "$APISIX_VERSION" = "master" ] || [ "$APISIX_VERSION" \> "2.2" ]; then echo 'use shell ';else bin='#! /usr/local/openresty/luajit/bin/luajit\npackage.path = "/usr/local/apisix/?.lua;" .. package.path'; sed -i "1s@.*@$bin@" /usr/bin/apisix ; fi;) \

--- a/all-in-one/apisix/Dockerfile
+++ b/all-in-one/apisix/Dockerfile
@@ -19,6 +19,7 @@ RUN set -x \
     pkgconfig \
     cmake \
     git \
+    && mkdir ~/.luarocks \
     && luarocks config variables.OPENSSL_LIBDIR /usr/local/openresty/openssl/lib \
     && luarocks config variables.OPENSSL_INCDIR /usr/local/openresty/openssl/include \
     && luarocks install https://github.com/apache/apisix/raw/master/rockspec/apisix-${APISIX_VERSION}-0.rockspec --tree=/usr/local/apisix/deps \

--- a/all-in-one/apisix/Dockerfile
+++ b/all-in-one/apisix/Dockerfile
@@ -23,8 +23,7 @@ RUN set -x \
     && luarocks config variables.OPENSSL_INCDIR /usr/local/openresty/openssl/include \
     && luarocks install https://github.com/apache/apisix/raw/master/rockspec/apisix-${APISIX_VERSION}-0.rockspec --tree=/usr/local/apisix/deps \
     && cp -v /usr/local/apisix/deps/lib/luarocks/rocks-5.1/apisix/${APISIX_VERSION}-0/bin/apisix /usr/bin/ \
-    && bin='#! /usr/local/openresty/luajit/bin/luajit\npackage.path = "/usr/local/apisix/?.lua;" .. package.path' \
-    && sed -i "1s@.*@$bin@" /usr/bin/apisix \
+    && (if [ "$APISIX_VERSION" = "master" ] || [ "$APISIX_VERSION" \> "2.2" ]; then echo 'use shell ';else bin='#! /usr/local/openresty/luajit/bin/luajit\npackage.path = "/usr/local/apisix/?.lua;" .. package.path'; sed -i "1s@.*@$bin@" /usr/bin/apisix ; fi;) \
     && mv /usr/local/apisix/deps/share/lua/5.1/apisix /usr/local/apisix \
     && apk del .builddeps build-base make unzip
 

--- a/all-in-one/apisix/Dockerfile
+++ b/all-in-one/apisix/Dockerfile
@@ -19,8 +19,8 @@ RUN set -x \
     pkgconfig \
     cmake \
     git \
-    && luarocks config variables.OPENSSL_LIBDIR /usr/local/openresty/openssl/lib \
-    && luarocks config variables.OPENSSL_INCDIR /usr/local/openresty/openssl/include \
+    && sudo luarocks config variables.OPENSSL_LIBDIR /usr/local/openresty/openssl/lib \
+    && sudo luarocks config variables.OPENSSL_INCDIR /usr/local/openresty/openssl/include \
     && luarocks install https://github.com/apache/apisix/raw/master/rockspec/apisix-${APISIX_VERSION}-0.rockspec --tree=/usr/local/apisix/deps \
     && cp -v /usr/local/apisix/deps/lib/luarocks/rocks-5.1/apisix/${APISIX_VERSION}-0/bin/apisix /usr/bin/ \
     && (if [ "$APISIX_VERSION" = "master" ] || [ "$APISIX_VERSION" \> "2.2" ]; then echo 'use shell ';else bin='#! /usr/local/openresty/luajit/bin/luajit\npackage.path = "/usr/local/apisix/?.lua;" .. package.path'; sed -i "1s@.*@$bin@" /usr/bin/apisix ; fi;) \

--- a/alpine-dev/Dockerfile
+++ b/alpine-dev/Dockerfile
@@ -12,8 +12,8 @@ RUN set -x \
     pkgconfig \
     cmake \
     git \
-    && sudo luarocks config variables.OPENSSL_LIBDIR /usr/local/openresty/openssl/lib \
-    && sudo luarocks config variables.OPENSSL_INCDIR /usr/local/openresty/openssl/include \
+    && luarocks config variables.OPENSSL_LIBDIR /usr/local/openresty/openssl/lib \
+    && luarocks config variables.OPENSSL_INCDIR /usr/local/openresty/openssl/include \
     && luarocks install https://github.com/apache/apisix/raw/master/rockspec/apisix-master-0.rockspec --tree=/usr/local/apisix/deps \
     && cp -v /usr/local/apisix/deps/lib/luarocks/rocks-5.1/apisix/master-0/bin/apisix /usr/bin/ \
     && mv /usr/local/apisix/deps/share/lua/5.1/apisix /usr/local/apisix \

--- a/alpine-dev/Dockerfile
+++ b/alpine-dev/Dockerfile
@@ -12,8 +12,8 @@ RUN set -x \
     pkgconfig \
     cmake \
     git \
-    && luarocks config variables.OPENSSL_LIBDIR /usr/local/openresty/openssl/lib \
-    && luarocks config variables.OPENSSL_INCDIR /usr/local/openresty/openssl/include \
+    && sudo luarocks config variables.OPENSSL_LIBDIR /usr/local/openresty/openssl/lib \
+    && sudo luarocks config variables.OPENSSL_INCDIR /usr/local/openresty/openssl/include \
     && luarocks install https://github.com/apache/apisix/raw/master/rockspec/apisix-master-0.rockspec --tree=/usr/local/apisix/deps \
     && cp -v /usr/local/apisix/deps/lib/luarocks/rocks-5.1/apisix/master-0/bin/apisix /usr/bin/ \
     && mv /usr/local/apisix/deps/share/lua/5.1/apisix /usr/local/apisix \

--- a/alpine-dev/Dockerfile
+++ b/alpine-dev/Dockerfile
@@ -16,8 +16,6 @@ RUN set -x \
     && luarocks config variables.OPENSSL_INCDIR /usr/local/openresty/openssl/include \
     && luarocks install https://github.com/apache/apisix/raw/master/rockspec/apisix-master-0.rockspec --tree=/usr/local/apisix/deps \
     && cp -v /usr/local/apisix/deps/lib/luarocks/rocks-5.1/apisix/master-0/bin/apisix /usr/bin/ \
-    && bin='#! /usr/local/openresty/luajit/bin/luajit\npackage.path = "/usr/local/apisix/?.lua;" .. package.path' \
-    && sed -i "1s@.*@$bin@" /usr/bin/apisix \
     && mv /usr/local/apisix/deps/share/lua/5.1/apisix /usr/local/apisix \
     && apk del .builddeps build-base make unzip
 

--- a/alpine-dev/Dockerfile
+++ b/alpine-dev/Dockerfile
@@ -12,6 +12,7 @@ RUN set -x \
     pkgconfig \
     cmake \
     git \
+    && mkdir ~/.luarocks \
     && luarocks config variables.OPENSSL_LIBDIR /usr/local/openresty/openssl/lib \
     && luarocks config variables.OPENSSL_INCDIR /usr/local/openresty/openssl/include \
     && luarocks install https://github.com/apache/apisix/raw/master/rockspec/apisix-master-0.rockspec --tree=/usr/local/apisix/deps \

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -19,8 +19,7 @@ RUN set -x \
     && luarocks config variables.OPENSSL_INCDIR /usr/local/openresty/openssl/include \
     && luarocks install https://github.com/apache/apisix/raw/master/rockspec/apisix-${APISIX_VERSION}-0.rockspec --tree=/usr/local/apisix/deps \
     && cp -v /usr/local/apisix/deps/lib/luarocks/rocks-5.1/apisix/${APISIX_VERSION}-0/bin/apisix /usr/bin/ \
-    && bin='#! /usr/local/openresty/luajit/bin/luajit\npackage.path = "/usr/local/apisix/?.lua;" .. package.path' \
-    && sed -i "1s@.*@$bin@" /usr/bin/apisix \
+    && (if [ "$APISIX_VERSION" = "master" ] || [ "$APISIX_VERSION" \> "2.2" ]; then echo 'use shell ';else bin='#! /usr/local/openresty/luajit/bin/luajit\npackage.path = "/usr/local/apisix/?.lua;" .. package.path'; sed -i "1s@.*@$bin@" /usr/bin/apisix ; fi;) \
     && mv /usr/local/apisix/deps/share/lua/5.1/apisix /usr/local/apisix \
     && apk del .builddeps build-base make unzip
 

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -15,8 +15,8 @@ RUN set -x \
     pkgconfig \
     cmake \
     git \
-    && luarocks config variables.OPENSSL_LIBDIR /usr/local/openresty/openssl/lib \
-    && luarocks config variables.OPENSSL_INCDIR /usr/local/openresty/openssl/include \
+    && sudo luarocks config variables.OPENSSL_LIBDIR /usr/local/openresty/openssl/lib \
+    && sudo luarocks config variables.OPENSSL_INCDIR /usr/local/openresty/openssl/include \
     && luarocks install https://github.com/apache/apisix/raw/master/rockspec/apisix-${APISIX_VERSION}-0.rockspec --tree=/usr/local/apisix/deps \
     && cp -v /usr/local/apisix/deps/lib/luarocks/rocks-5.1/apisix/${APISIX_VERSION}-0/bin/apisix /usr/bin/ \
     && (if [ "$APISIX_VERSION" = "master" ] || [ "$APISIX_VERSION" \> "2.2" ]; then echo 'use shell ';else bin='#! /usr/local/openresty/luajit/bin/luajit\npackage.path = "/usr/local/apisix/?.lua;" .. package.path'; sed -i "1s@.*@$bin@" /usr/bin/apisix ; fi;) \

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -15,8 +15,8 @@ RUN set -x \
     pkgconfig \
     cmake \
     git \
-    && sudo luarocks config variables.OPENSSL_LIBDIR /usr/local/openresty/openssl/lib \
-    && sudo luarocks config variables.OPENSSL_INCDIR /usr/local/openresty/openssl/include \
+    && luarocks config variables.OPENSSL_LIBDIR /usr/local/openresty/openssl/lib \
+    && luarocks config variables.OPENSSL_INCDIR /usr/local/openresty/openssl/include \
     && luarocks install https://github.com/apache/apisix/raw/master/rockspec/apisix-${APISIX_VERSION}-0.rockspec --tree=/usr/local/apisix/deps \
     && cp -v /usr/local/apisix/deps/lib/luarocks/rocks-5.1/apisix/${APISIX_VERSION}-0/bin/apisix /usr/bin/ \
     && (if [ "$APISIX_VERSION" = "master" ] || [ "$APISIX_VERSION" \> "2.2" ]; then echo 'use shell ';else bin='#! /usr/local/openresty/luajit/bin/luajit\npackage.path = "/usr/local/apisix/?.lua;" .. package.path'; sed -i "1s@.*@$bin@" /usr/bin/apisix ; fi;) \

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -15,6 +15,7 @@ RUN set -x \
     pkgconfig \
     cmake \
     git \
+    && mkdir ~/.luarocks \
     && luarocks config variables.OPENSSL_LIBDIR /usr/local/openresty/openssl/lib \
     && luarocks config variables.OPENSSL_INCDIR /usr/local/openresty/openssl/include \
     && luarocks install https://github.com/apache/apisix/raw/master/rockspec/apisix-${APISIX_VERSION}-0.rockspec --tree=/usr/local/apisix/deps \


### PR DESCRIPTION
Fix: `/usr/bin/apisix` use `bash` after version 2.3.