### PR TITLE
feat: we can use kubectl logs and docker logs review apisix container's logs.

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -40,6 +40,10 @@ COPY --from=production-stage /usr/bin/apisix /usr/bin/apisix
 
 ENV PATH=$PATH:/usr/local/openresty/luajit/bin:/usr/local/openresty/nginx/sbin:/usr/local/openresty/bin
 
+# apisix's logs will output the stdout and stderr. we can use commend `kubectl logs` and `docker logs` review apisix's logs   
+RUN  ln -sf /dev/stdout /usr/local/apisix/logs/access.log \
+    && ln -sf /dev/stderr /usr/local/apisix/logs/error.log
+
 EXPOSE 9080 9443
 
 CMD ["sh", "-c", "/usr/bin/apisix init && /usr/bin/apisix init_etcd && /usr/local/openresty/bin/openresty -p /usr/local/apisix -g 'daemon off;'"]

--- a/centos/Dockerfile
+++ b/centos/Dockerfile
@@ -12,6 +12,11 @@ RUN yum -y install yum-utils\
 
 WORKDIR /usr/local/apisix
 
+# apisix's logs will output the stdout and stderr. we can use commend `kubectl logs` and `docker logs` review apisix's logs   
+RUN  ln -sf /dev/stdout /usr/local/apisix/logs/access.log \
+    && ln -sf /dev/stderr /usr/local/apisix/logs/error.log
+
+
 EXPOSE 9080 9443
 
 CMD ["sh", "-c", "/usr/bin/apisix init && /usr/bin/apisix init_etcd && /usr/local/openresty/bin/openresty -p /usr/local/apisix -g 'daemon off;'"]


### PR DESCRIPTION
we can use `kubectl logs` and `docker logs` review apisix container's logs

```shell
kubectl -n <YOUR_NAMEPSACES> logs <APISIX_POD>
docker logs <APISIX_CONTAINERS>
```