### PR TITLE
ci: execute ci about apisix and dashboard when pull_request

### DIFF
--- a/.github/workflows/apisix_all_in_one_ci.yaml
+++ b/.github/workflows/apisix_all_in_one_ci.yaml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build:

--- a/.github/workflows/dashboard_all_in_one_ci.yaml
+++ b/.github/workflows/dashboard_all_in_one_ci.yaml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build:

--- a/all-in-one/apisix-dashboard/Dockerfile
+++ b/all-in-one/apisix-dashboard/Dockerfile
@@ -124,6 +124,6 @@ RUN mkdir logs
 
 EXPOSE 9080 9443 2379 2380 9000
 
-CMD ["sh", "-c", "(nohup etcd >/tmp/etcd.log 2>&1 &) && sleep 10 && (/usr/local/apisix-dashboard/manager-api &) && /usr/bin/apisix init && /usr/bin/apisix init_etcd && /usr/local/openresty/bin/openresty -p /usr/local/apisix -g 'daemon off;'"]
+CMD ["sh", "-c", "(nohup etcd >/tmp/etcd.log 2>&1 &) && sleep 10 && (/usr/local/apisix-dashboard/manager-api &) && cd /usr/local/apisix && /usr/bin/apisix init && /usr/bin/apisix init_etcd && /usr/local/openresty/bin/openresty -p /usr/local/apisix -g 'daemon off;'"]
 
 STOPSIGNAL SIGQUIT


### PR DESCRIPTION
`apisix_all_in_one_ci.yaml` and `dashboard_all_in_one_ci.yaml`should be executed in the phase of pull_request.

Related to #126 
