### PR TITLE
feat: Upgrade default versions of apisix and apisix-dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ $ docker run -v `pwd`/all-in-one/apisix/config.yaml:/usr/local/apisix/conf/confi
 
 * All in one Docker container for Apache apisix-dashboard
 
-**The latest version of `apisix-dashboard` is 2.3 and should be used with APISIX 2.2.**
+**The latest version of `apisix-dashboard` is 2.4 and should be used with APISIX 2.3.**
 
 ```shell
 $ docker build --build-arg APISIX_VERSION=2.2 --build-arg APISIX_DASHBOARD_VERSION=v2.3 -t apache/apisix-dashboard:whole -f ./all-in-one/apisix-dashboard/Dockerfile .

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -2,7 +2,7 @@ ARG ENABLE_PROXY=false
 
 FROM openresty/openresty:alpine-fat AS production-stage
 
-ARG APISIX_VERSION=2.2
+ARG APISIX_VERSION=2.3
 LABEL apisix_version="${APISIX_VERSION}"
 
 ARG ENABLE_PROXY

--- a/centos/Dockerfile
+++ b/centos/Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:7
 
-ARG APISIX_VERSION=2.2
+ARG APISIX_VERSION=2.3
 LABEL apisix_version="${APISIX_VERSION}"
 
 RUN yum -y install yum-utils\

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   apisix:
-    image: apache/apisix:2.2-alpine
+    image: apache/apisix:2.3-alpine
     restart: always
     volumes:
       - ./apisix_log:/usr/local/apisix/logs


### PR DESCRIPTION
Signed-off-by: imjoey <majunjie@apache.org>

As the releases of APISIX 2.3 and dashboard 2.4, this PR is going to upgrade the default versions in relevant dockerfiles and docs. This would let users have the latest stable releases by default.