### PR TITLE
feat: redirect container logs to stdout and stderr

### DIFF
--- a/all-in-one/apisix/Dockerfile
+++ b/all-in-one/apisix/Dockerfile
@@ -58,6 +58,10 @@ COPY --from=production-stage /usr/bin/apisix /usr/bin/apisix
 COPY --from=etcd-stage /tmp/etcd/etcd /usr/bin/etcd
 COPY --from=etcd-stage /tmp/etcd/etcdctl /usr/bin/etcdctl
 
+# forward request and error logs to docker log driver
+RUN ln -sf /dev/stdout /usr/local/apisix/logs/access.log \
+  && ln -sf /dev/stderr /usr/local/apisix/logs/error.log
+
 ENV PATH=$PATH:/usr/local/openresty/luajit/bin:/usr/local/openresty/nginx/sbin:/usr/local/openresty/bin
 
 EXPOSE 9080 9443 2379 2380

--- a/alpine-dev/Dockerfile
+++ b/alpine-dev/Dockerfile
@@ -34,6 +34,10 @@ COPY --from=production-stage /usr/local/openresty/ /usr/local/openresty/
 COPY --from=production-stage /usr/local/apisix/ /usr/local/apisix/
 COPY --from=production-stage /usr/bin/apisix /usr/bin/apisix
 
+# forward request and error logs to docker log driver
+RUN ln -sf /dev/stdout /usr/local/apisix/logs/access.log \
+  && ln -sf /dev/stderr /usr/local/apisix/logs/error.log
+
 ENV PATH=$PATH:/usr/local/openresty/luajit/bin:/usr/local/openresty/nginx/sbin:/usr/local/openresty/bin
 
 EXPOSE 9080 9443

--- a/alpine-local/Dockerfile
+++ b/alpine-local/Dockerfile
@@ -34,6 +34,10 @@ COPY --from=production-stage /usr/local/openresty/ /usr/local/openresty/
 COPY --from=production-stage /usr/local/apisix/ /usr/local/apisix/
 COPY --from=production-stage /usr/bin/apisix /usr/bin/apisix
 
+# forward request and error logs to docker log driver
+RUN ln -sf /dev/stdout /usr/local/apisix/logs/access.log \
+  && ln -sf /dev/stderr /usr/local/apisix/logs/error.log
+
 ENV PATH=$PATH:/usr/local/openresty/luajit/bin:/usr/local/openresty/nginx/sbin:/usr/local/openresty/bin
 
 EXPOSE 9080 9443

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -38,6 +38,10 @@ COPY --from=production-stage /usr/local/openresty/ /usr/local/openresty/
 COPY --from=production-stage /usr/local/apisix/ /usr/local/apisix/
 COPY --from=production-stage /usr/bin/apisix /usr/bin/apisix
 
+# forward request and error logs to docker log driver
+RUN ln -sf /dev/stdout /usr/local/apisix/logs/access.log \
+  && ln -sf /dev/stderr /usr/local/apisix/logs/error.log
+
 ENV PATH=$PATH:/usr/local/openresty/luajit/bin:/usr/local/openresty/nginx/sbin:/usr/local/openresty/bin
 
 EXPOSE 9080 9443

--- a/centos/Dockerfile
+++ b/centos/Dockerfile
@@ -12,6 +12,10 @@ RUN yum -y install yum-utils\
 
 WORKDIR /usr/local/apisix
 
+# forward request and error logs to docker log driver
+RUN ln -sf /dev/stdout /usr/local/apisix/logs/access.log \
+  && ln -sf /dev/stderr /usr/local/apisix/logs/error.log
+
 EXPOSE 9080 9443
 
 CMD ["sh", "-c", "/usr/bin/apisix init && /usr/bin/apisix init_etcd && /usr/local/openresty/bin/openresty -p /usr/local/apisix -g 'daemon off;'"]


### PR DESCRIPTION
This PR redirects the container logs to `stdout` and `stderr` so all logs go to the docker log driver. We may also tail the logs via `kubectl logs` or `docker logs`.

Duplicate and related to #128 
Closes #149 