### PR TITLE
fix: use openresy 1.19.3.1 as alpine's base image

### DIFF
--- a/all-in-one/apisix-dashboard/Dockerfile
+++ b/all-in-one/apisix-dashboard/Dockerfile
@@ -4,7 +4,7 @@ ARG APISIX_VERSION=master
 ARG APISIX_DASHBOARD_VERSION=master
 
 # Build Apache APISIX
-FROM openresty/openresty:alpine-fat AS production-stage
+FROM openresty/openresty:1.19.3.1-alpine-fat AS production-stage
 
 ARG APISIX_VERSION
 ARG ENABLE_PROXY

--- a/all-in-one/apisix/Dockerfile
+++ b/all-in-one/apisix/Dockerfile
@@ -3,7 +3,7 @@ ARG APISIX_VERSION=master
 ARG ETCD_VERSION=v3.4.14
 
 # Build Apache APISIX
-FROM openresty/openresty:alpine-fat AS production-stage
+FROM openresty/openresty:1.19.3.1-alpine-fat AS production-stage
 
 ARG APISIX_VERSION
 LABEL apisix_version="${APISIX_VERSION}"

--- a/alpine-dev/Dockerfile
+++ b/alpine-dev/Dockerfile
@@ -1,6 +1,6 @@
 ARG ENABLE_PROXY=false
 
-FROM openresty/openresty:alpine-fat AS production-stage
+FROM openresty/openresty:1.19.3.1-alpine-fat AS production-stage
 
 ARG ENABLE_PROXY
 RUN set -x \

--- a/alpine-local/Dockerfile
+++ b/alpine-local/Dockerfile
@@ -1,6 +1,6 @@
 ARG ENABLE_PROXY=false
 
-FROM openresty/openresty:alpine-fat AS production-stage
+FROM openresty/openresty:1.19.3.1-alpine-fat AS production-stage
 
 ARG ENABLE_PROXY
 ARG APISIX_PATH

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,6 +1,6 @@
 ARG ENABLE_PROXY=false
 
-FROM openresty/openresty:alpine-fat AS production-stage
+FROM openresty/openresty:1.19.3.1-alpine-fat AS production-stage
 
 ARG APISIX_VERSION=2.4
 LABEL apisix_version="${APISIX_VERSION}"


### PR DESCRIPTION
Signed-off-by: yiyiyimu <wosoyoung@gmail.com>

The default [`alpine-fat`](https://hub.docker.com/layers/openresty/openresty/alpine-fat/images/sha256-87b7cddf36e76c42da26143e049745f58e341efa21e6471fc71cab188c42bc48?context=explore) uses openresty `v1.15.8.3`, which APISIX have already discarded. So we need to explicitly specify openresty version

Ref: https://github.com/apache/apisix/pull/3912/checks?check_run_id=2198667421#step:7:354