### PR TITLE
feat: timezone support via startup environment `TZ`

### DIFF
--- a/alpine-dev/Dockerfile
+++ b/alpine-dev/Dockerfile
@@ -26,7 +26,7 @@ ARG ENABLE_PROXY
 # add runtime for Apache APISIX
 RUN set -x \
     && (test "${ENABLE_PROXY}" != "true" || /bin/sed -i 's,http://dl-cdn.alpinelinux.org,https://mirrors.aliyun.com,g' /etc/apk/repositories) \
-    && apk add --no-cache bash libstdc++ curl
+    && apk add --no-cache bash libstdc++ curl tzdata
 
 WORKDIR /usr/local/apisix
 

--- a/alpine-local/Dockerfile
+++ b/alpine-local/Dockerfile
@@ -26,7 +26,7 @@ ARG ENABLE_PROXY
 # add runtime for Apache APISIX
 RUN set -x \
     && (test "${ENABLE_PROXY}" != "true" || /bin/sed -i 's,http://dl-cdn.alpinelinux.org,https://mirrors.aliyun.com,g' /etc/apk/repositories) \
-    && apk add --no-cache bash libstdc++ curl
+    && apk add --no-cache bash libstdc++ curl tzdata
 
 WORKDIR /usr/local/apisix
 

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -30,7 +30,7 @@ ARG ENABLE_PROXY
 # add runtime for Apache APISIX
 RUN set -x \
     && (test "${ENABLE_PROXY}" != "true" || /bin/sed -i 's,http://dl-cdn.alpinelinux.org,https://mirrors.aliyun.com,g' /etc/apk/repositories) \
-    && apk add --no-cache bash libstdc++ curl
+    && apk add --no-cache bash libstdc++ curl tzdata
 
 WORKDIR /usr/local/apisix
 

--- a/centos/Dockerfile
+++ b/centos/Dockerfile
@@ -5,7 +5,7 @@ LABEL apisix_version="${APISIX_VERSION}"
 
 RUN yum -y install yum-utils\
 	&& yum-config-manager --add-repo https://openresty.org/package/centos/openresty.repo \
-	&& yum install -y openresty which \
+	&& yum install -y openresty which tzdata \
 	&& yum install -y https://github.com/apache/apisix/releases/download/$APISIX_VERSION/apisix-$APISIX_VERSION-0.x86_64.rpm \
 	&& yum clean all \
 	&& sed -i 's/PASS_MAX_DAYS\t99999/PASS_MAX_DAYS\t60/g' /etc/login.defs


### PR DESCRIPTION
usage:

```
    environment:
      - "TZ=Asia/Shanghai"

```