### PR TITLE
fix: upgrade alpine version due to CVE-2020-28928

### DIFF
--- a/all-in-one/apisix-dashboard/Dockerfile
+++ b/all-in-one/apisix-dashboard/Dockerfile
@@ -30,7 +30,7 @@ RUN set -x \
 
 
 # Build etcd
-FROM alpine:3.11 AS etcd-stage
+FROM alpine:3.13 AS etcd-stage
 
 ARG ETCD_VERSION
 LABEL etcd_version="${ETCD_VERSION}"
@@ -90,7 +90,7 @@ RUN if [ "$ENABLE_PROXY" = "true" ] ; then yarn config set registry https://regi
     && yarn build
 
 # Finally combine all the resources into one image
-FROM alpine:3.11 AS last-stage
+FROM alpine:3.13 AS last-stage
 
 ARG ENABLE_PROXY
 

--- a/all-in-one/apisix/Dockerfile
+++ b/all-in-one/apisix/Dockerfile
@@ -29,7 +29,7 @@ RUN set -x \
     && apk del .builddeps build-base make unzip
 
 # Build etcd
-FROM alpine:3.11 AS etcd-stage
+FROM alpine:3.13 AS etcd-stage
 
 ARG ETCD_VERSION
 LABEL etcd_version="${ETCD_VERSION}"
@@ -41,7 +41,7 @@ RUN wget https://github.com/etcd-io/etcd/releases/download/${ETCD_VERSION}/etcd-
     && ln -s etcd-${ETCD_VERSION}-linux-amd64 etcd
 
 # Finally combine all the resources into one image
-FROM alpine:3.11 AS last-stage
+FROM alpine:3.13 AS last-stage
 
 ARG ENABLE_PROXY
 # add runtime for Apache APISIX

--- a/alpine-dev/Dockerfile
+++ b/alpine-dev/Dockerfile
@@ -20,7 +20,7 @@ RUN set -x \
     && mv /usr/local/apisix/deps/share/lua/5.1/apisix /usr/local/apisix \
     && apk del .builddeps build-base make unzip
 
-FROM alpine:3.11 AS last-stage
+FROM alpine:3.13 AS last-stage
 
 ARG ENABLE_PROXY
 # add runtime for Apache APISIX

--- a/alpine-local/Dockerfile
+++ b/alpine-local/Dockerfile
@@ -20,7 +20,7 @@ RUN set -x \
     && mv ../apisix /usr/local/apisix \
     && apk del .builddeps build-base make unzip
 
-FROM alpine:3.11 AS last-stage
+FROM alpine:3.13 AS last-stage
 
 ARG ENABLE_PROXY
 # add runtime for Apache APISIX

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -24,7 +24,7 @@ RUN set -x \
     && mv /usr/local/apisix/deps/share/lua/5.1/apisix /usr/local/apisix \
     && apk del .builddeps build-base make unzip
 
-FROM alpine:3.11 AS last-stage
+FROM alpine:3.13 AS last-stage
 
 ARG ENABLE_PROXY
 # add runtime for Apache APISIX


### PR DESCRIPTION
musl	CVE-2020-28928	 	fixed in 1.2.2_pre2-r0	4	

Published: >4 months agoIn musl libc through 1.2.1, wcsnrtombs mishandles particular combinations of destination buffer size and source character limit, as demonstrated by an invalid write access (buffer overflow).




xref: https://nvd.nist.gov/vuln/detail/CVE-2020-28928



Signed-off-by: Jintao Zhang <zhangjintao9020@gmail.com>