### PR TITLE
fix: remove example/docker-compose.yml static ip address

### DIFF
--- a/example/docker-compose-alpine.yml
+++ b/example/docker-compose-alpine.yml
@@ -18,7 +18,6 @@ services:
       - "9443:9443/tcp"
     networks:
       apisix:
-        ipv4_address: 172.18.5.11
 
   etcd:
     image: bitnami/etcd:3.4.9
@@ -36,7 +35,6 @@ services:
       - "2379:2379/tcp"
     networks:
       apisix:
-        ipv4_address: 172.18.5.10
 
   web1:
     image: nginx:1.18.0-alpine
@@ -49,7 +47,6 @@ services:
       - NGINX_PORT=80
     networks:
       apisix:
-        ipv4_address: 172.18.5.12
 
   web2:
     image: nginx:1.18.0-alpine
@@ -62,11 +59,7 @@ services:
       - NGINX_PORT=80
     networks:
       apisix:
-        ipv4_address: 172.18.5.13
 
 networks:
   apisix:
     driver: bridge
-    ipam:
-      config:
-      - subnet: 172.18.0.0/16

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -10,7 +10,6 @@ services:
     - "9000:9000"
     networks:
       apisix:
-        ipv4_address: 172.18.5.15
 
   apisix:
     image: apache/apisix:2.3-alpine
@@ -26,7 +25,6 @@ services:
       - "9443:9443/tcp"
     networks:
       apisix:
-        ipv4_address: 172.18.5.11
 
   etcd:
     image: bitnami/etcd:3.4.9
@@ -44,7 +42,6 @@ services:
       - "2379:2379/tcp"
     networks:
       apisix:
-        ipv4_address: 172.18.5.10
 
   web1:
     image: nginx:1.18.0-alpine
@@ -57,7 +54,6 @@ services:
       - NGINX_PORT=80
     networks:
       apisix:
-        ipv4_address: 172.18.5.12
 
   web2:
     image: nginx:1.18.0-alpine
@@ -70,11 +66,7 @@ services:
       - NGINX_PORT=80
     networks:
       apisix:
-        ipv4_address: 172.18.5.13
 
 networks:
   apisix:
     driver: bridge
-    ipam:
-      config:
-      - subnet: 172.18.0.0/16


### PR DESCRIPTION
In this example, it is not necessary to specify static ip to complete its function.
If static ip is specified, the operation will fail due to network segment conflicts.