### PR TITLE
docs: broken link in docker manual page

### DIFF
--- a/docs/en/latest/manual.md
+++ b/docs/en/latest/manual.md
@@ -55,7 +55,7 @@ docker run -it --name etcd-server \
 
 ### Run Apache APISIX server
 
-You need etcd docker to work with Apache APISIX. You can refer to [the docker-compose example](example/README.md).
+You need etcd docker to work with Apache APISIX. You can refer to [the docker-compose example](example.md).
 
 Or you can run APISIX with Docker directly（Docker name is test-api-gateway）:
 


### PR DESCRIPTION
fix: [#325](https://github.com/apache/apisix-website/issues/325)