### PR TITLE
ci: change new release trigger from release to release branch

### DIFF
--- a/.github/workflows/apisix_push_docker_hub.yaml
+++ b/.github/workflows/apisix_push_docker_hub.yaml
@@ -1,7 +1,7 @@
 name: Push apisix to Docker image
 on:
-  release:
-    types: [ published ]
+  push:
+    branches: ['release/apisix-**']
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/dashboard_push_docker_hub.yaml
+++ b/.github/workflows/dashboard_push_docker_hub.yaml
@@ -1,7 +1,7 @@
 name: Push apisix dashboard to Docker image
 on:
-  release:
-    types: [ published ]
+  push:
+    branches: ['release/dashboard**']
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -2,4 +2,4 @@
 
 To make and publish new docker images on docker hub, maintainers should create branch under `apisix-docker` repo with specific name.
 
-For apisix and dashboard new version, the branch name should use prefix `release/apisix` and `release/dashboard` seperately. Remember to delete the release branch after the new images published, since the branch would got no use afterwards.
+For apisix and dashboard new version, the branch name should use prefix `release/apisix` and `release/dashboard` separately (e.g. `release/apisix-2.6`, `release/dashboard-2.6`). Remember to delete the release branch after the new images published, since the branch would got no use afterwards.

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -1,0 +1,5 @@
+## New release
+
+To make and publish new docker images on docker hub, maintainers should create branch under `apisix-docker` repo with specific name.
+
+For apisix and dashboard new version, the branch name should use prefix `release/apisix` and `release/dashboard` seperately. Remember to delete the release branch after the new images published, since the branch would got no use afterwards.

--- a/Makefile
+++ b/Makefile
@@ -36,11 +36,13 @@ build-on-alpine:
 # Actually it is not build on certain version but on local code
 # Use this name (in the same patterns with others) for convenient CI
 build-on-alpine-local:
-	docker build -t $(IMAGE_NAME):$(APISIX_VERSION)-alpine-local --build-arg APISIX_PATH=${APISIX_PATH} -f ./alpine-local/Dockerfile .	
+	docker build -t $(IMAGE_NAME):$(APISIX_VERSION)-alpine-local --build-arg APISIX_PATH=${APISIX_PATH} -f ./alpine-local/Dockerfile .
 
 ### push-on-centos:       Push apache/apisix:xx-centos image
 push-on-centos:
 	docker push $(IMAGE_NAME):$(APISIX_VERSION)-centos
+	docker build -t $(IMAGE_NAME):latest -f ./centos/Dockerfile .
+	docker push $(IMAGE_NAME):latest
 
 ### push-on-alpine:       Push apache/apisix:xx-alpine image
 push-on-alpine:
@@ -71,6 +73,8 @@ build-dashboard:
 ### push-dashboard:     Push apache/dashboard:tag image
 push-dashboard:
 	docker push $(APISIX_DASHBOARD_IMAGE_NAME):$(APISIX_DASHBOARD_VERSION)
+	docker build -t $(APISIX_DASHBOARD_IMAGE_NAME):latest -f ./dashboard/Dockerfile .
+	docker push $(APISIX_DASHBOARD_IMAGE_NAME):latest
 
 ### save-dashboard-tar:      tar apache/apisix-dashboard:tag image
 save-dashboard-tar:


### PR DESCRIPTION
Signed-off-by: yiyiyimu <wosoyoung@gmail.com>

1. change new release trigger from release to release branch, to simplify new release publishment process
2. also push latest image when make release