### PR TITLE
docs: removed navigation title from sidebar to docs dropdown

### DIFF
--- a/docs/en/latest/config.json
+++ b/docs/en/latest/config.json
@@ -2,11 +2,6 @@
   "version": 1.0,
   "sidebar": [
     {
-      "type": "link",
-      "label": "Apache APISIX™ Docker",
-      "href": "https://apisix.apache.org/docs/docker/build/"
-    },
-    {
       "type": "category",
       "label": "Installation",
       "items": [ "build", "manual", "example"]


### PR DESCRIPTION
fixed issue: [#360 from apisix-website](https://github.com/apache/apisix-website/issues/360)

##Description
To remove navigation title from sidebar to docs dropdown