### PR TITLE
feat: release apisix docker image by tags

### DIFF
--- a/.github/workflows/apisix_push_docker_hub.yaml
+++ b/.github/workflows/apisix_push_docker_hub.yaml
@@ -1,7 +1,10 @@
 name: Push apisix to Docker image
 on:
   push:
-    branches: ['release/apisix-**']
+    branches-ignore:
+      - '**'
+    tags:
+      - 'apisix-*'
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -12,6 +15,12 @@ jobs:
           - centos
 
     steps:
+      - name: Prepare
+        id: prepare
+        run: |
+          TAG=${GITHUB_REF#refs/tags/apisix-}
+          echo ::set-output name=tag_name::${TAG}
+
       - name: Check out the repo
         uses: actions/checkout@v2
 
@@ -19,6 +28,13 @@ jobs:
         run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login --username=${{ secrets.DOCKER_USERNAME }} --password-stdin
 
       - name: Push apisix image to Docker Hub
-        run:
-          make build-on-${{ matrix.platform }}
-          make push-on-${{ matrix.platform }}
+        env:
+          # fork friendly ^^
+          DOCKER_REPO: ${{ secrets.DOCKER_REPO }}
+        run: |
+          docker build \
+          --build-arg APISIX_VERSION=${{ steps.prepare.outputs.tag_name }} \
+          -t ${DOCKER_REPO:-apisix/apisix}:${{ steps.prepare.outputs.tag_name }}-${{ matrix.platform }} \
+          -f ./${{ matrix.platform }}/Dockerfile \
+          .
+          docker push ${DOCKER_REPO:-apisix/apisix}:${{ steps.prepare.outputs.tag_name }}-${{ matrix.platform }} 

--- a/README.md
+++ b/README.md
@@ -81,3 +81,9 @@ Tips: If there is a port conflict, please modify the host port through `docker r
 ```shell
 $ docker run -v `pwd`/all-in-one/apisix/config.yaml:/usr/local/apisix/conf/config.yaml -v `pwd`/all-in-one/apisix-dashboard/conf.yaml:/usr/local/apisix-dashboard/conf/conf.yaml -p 19080:9080 -p 12379:2379 -p 19000:9000 -d apache/apisix-dashboard:whole
 ```
+
+## release apisix docker image
+
+```
+git tag apisix-2.7 && git push orgin --tags apisix-2.7
+```


### PR DESCRIPTION
Usege

```
git tag apisix-2.7 && git push origin --tags apisix-2.7
```

build logs: 

https://github.com/oldthreefeng/apisix-docker/actions/runs/970587183

if apisix-dashboard use this action. 

i can also make the changes like. ( on the way)

```
git tag dashboard-2.7 && git push origin --tags dashboard-2.7
```