### PR TITLE
docs: removed `$` from code snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,28 +11,29 @@
 # Assign Apache release version number to variable `APISIX_VERSION`, for example: 2.6. The latest version can be find at `https://github.com/apache/apisix/releases`
 
 export APISIX_VERSION=2.6
+
 # alpine
-$ make build-on-alpine
+make build-on-alpine
 
 # centos
-$ make build-on-centos
+make build-on-centos
 ```
 
 2. Build from master branch version, which has latest code(ONLY for the developer's convenience):
 ```sh
 export APISIX_VERSION=master
+
 # alpine
-$ make build-on-alpine
+make build-on-alpine
 
 # centos
-$ make build-on-centos
+make build-on-centos
 ```
 
 3. Build from local code:
 ```sh
 # To copy apisix into image, we need to include it in build context
-$ cp -r <APISIX-PATH> ./apisix
-$ APISIX_PATH=./apisix make build-on-alpine-local
+cp -r <APISIX-PATH> ./apisiAPISIX_PATH=./apisix make build-on-alpine-local
 
 # Might need root privilege if encounter "error checking context: 'can't stat'"
 ```
@@ -40,7 +41,7 @@ $ APISIX_PATH=./apisix make build-on-alpine-local
 **Note:** For Chinese, the following command is always recommended. The additional build argument `ENABLE_PROXY=true` will enable proxy to definitely accelerate the progress.
 
 ```sh
-$ make build-on-alpine-cn
+make build-on-alpine-cn
 ```
 
 ### Manual deploy apisix via docker
@@ -52,8 +53,9 @@ $ make build-on-alpine-cn
 **start all modules with docker-compose**
 
 ```sh
-$ cd example
-$ docker-compose -p docker-apisix up -d
+cd example
+
+docker-compose -p docker-apisix up -d
 ```
 
 You can refer to [the docker-compose example](docs/en/latest/example.md) for more try.
@@ -63,8 +65,9 @@ You can refer to [the docker-compose example](docs/en/latest/example.md) for mor
 * All in one Docker container for Apache APISIX
 
 ```shell
-$ make build-all-in-one
-$ docker run -v `pwd`/all-in-one/apisix/config.yaml:/usr/local/apisix/conf/config.yaml -p 9080:9080 -p 2379:2379 -d apache/apisix:whole
+make build-all-in-one
+
+docker run -v `pwd`/all-in-one/apisix/config.yaml:/usr/local/apisix/conf/config.yaml -p 9080:9080 -p 2379:2379 -d apache/apisix:whole
 ```
 
 * All in one Docker container for Apache apisix-dashboard
@@ -72,12 +75,13 @@ $ docker run -v `pwd`/all-in-one/apisix/config.yaml:/usr/local/apisix/conf/confi
 **The latest version of `apisix-dashboard` is 2.7 and should be used with APISIX 2.6.**
 
 ```shell
-$ make build-dashboard
-$ docker run -v `pwd`/all-in-one/apisix/config.yaml:/usr/local/apisix/conf/config.yaml -v `pwd`/all-in-one/apisix-dashboard/conf.yaml:/usr/local/apisix-dashboard/conf/conf.yaml -p 9080:9080 -p 2379:2379 -p 9000:9000 -d apache/apisix-dashboard:whole
+make build-dashboard
+
+docker run -v `pwd`/all-in-one/apisix/config.yaml:/usr/local/apisix/conf/config.yaml -v `pwd`/all-in-one/apisix-dashboard/conf.yaml:/usr/local/apisix-dashboard/conf/conf.yaml -p 9080:9080 -p 2379:2379 -p 9000:9000 -d apache/apisix-dashboard:whole
 ```
 
 Tips: If there is a port conflict, please modify the host port through `docker run -p`, e.g.
 
 ```shell
-$ docker run -v `pwd`/all-in-one/apisix/config.yaml:/usr/local/apisix/conf/config.yaml -v `pwd`/all-in-one/apisix-dashboard/conf.yaml:/usr/local/apisix-dashboard/conf/conf.yaml -p 19080:9080 -p 12379:2379 -p 19000:9000 -d apache/apisix-dashboard:whole
+docker run -v `pwd`/all-in-one/apisix/config.yaml:/usr/local/apisix/conf/config.yaml -v `pwd`/all-in-one/apisix-dashboard/conf.yaml:/usr/local/apisix-dashboard/conf/conf.yaml -p 19080:9080 -p 12379:2379 -p 19000:9000 -d apache/apisix-dashboard:whole
 ```

--- a/docs/en/latest/example.md
+++ b/docs/en/latest/example.md
@@ -26,7 +26,7 @@ title: Example
 ### Run
 
 ```
-$ docker-compose -p docker-apisix up -d
+docker-compose -p docker-apisix up -d
 ```
 
 ### Configure
@@ -99,9 +99,9 @@ curl https://web1.lvh.me:9443/ -v --cacert ./mkcert/rootCA.pem
 ### Clean
 
 ```
-$ docker-compose -p docker-apisix down
+docker-compose -p docker-apisix down
 
-$ sudo rm -rf etcd_data/member
+sudo rm -rf etcd_data/member
 
-$ rm -rf apisix_log/*.log
+rm -rf apisix_log/*.log
 ```


### PR DESCRIPTION
removed `$` from code snippets so that while copying from copy button on copy buttons doesn't copy trailing dollars

@spacewander @Yiyiyimu 