### PR TITLE
ci: add apisix release on multiarch

### DIFF
--- a/.github/workflows/apisix_push_docker_hub.yaml
+++ b/.github/workflows/apisix_push_docker_hub.yaml
@@ -1,7 +1,5 @@
 name: Push apisix to Docker image
-on:
-  push:
-    branches: ['release/apisix-**']
+on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/apisix_push_docker_hub.yaml
+++ b/.github/workflows/apisix_push_docker_hub.yaml
@@ -3,11 +3,6 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        platform:
-          - alpine
-          - centos
 
     steps:
       - name: Check out the repo
@@ -24,4 +19,6 @@ jobs:
 
       - name: Push apisix image to Docker Hub
         run:
-          make push-multiarch-on-${{ matrix.platform }}
+          make push-multiarch-on-alpine
+          make build-on-centos
+          make push-on-centos

--- a/.github/workflows/apisix_push_docker_hub.yaml
+++ b/.github/workflows/apisix_push_docker_hub.yaml
@@ -1,5 +1,5 @@
 name: Push apisix to Docker image
-on: [push, pull_request]
+on: [pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -18,7 +18,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       - name: Push apisix image to Docker Hub
-        run:
+        run: |
           make push-multiarch-on-alpine
           make build-on-centos
           make push-on-centos

--- a/.github/workflows/apisix_push_docker_hub.yaml
+++ b/.github/workflows/apisix_push_docker_hub.yaml
@@ -18,7 +18,10 @@ jobs:
       - name: Login
         run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login --username=${{ secrets.DOCKER_USERNAME }} --password-stdin
 
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
       - name: Push apisix image to Docker Hub
         run:
-          make build-on-${{ matrix.platform }}
-          make push-on-${{ matrix.platform }}
+          make push-multiarch-on-${{ matrix.platform }}

--- a/.github/workflows/apisix_push_docker_hub.yaml
+++ b/.github/workflows/apisix_push_docker_hub.yaml
@@ -18,8 +18,10 @@ jobs:
       - name: Login
         run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login --username=${{ secrets.DOCKER_USERNAME }} --password-stdin
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
       - name: Set up Docker Buildx
-        id: buildx
         uses: docker/setup-buildx-action@v1
 
       - name: Push apisix image to Docker Hub

--- a/.github/workflows/dashboard_push_docker_hub.yaml
+++ b/.github/workflows/dashboard_push_docker_hub.yaml
@@ -13,6 +13,9 @@ jobs:
       - name: Login
         run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login --username=${{ secrets.DOCKER_USERNAME }} --password-stdin
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1

--- a/.github/workflows/dashboard_push_docker_hub.yaml
+++ b/.github/workflows/dashboard_push_docker_hub.yaml
@@ -13,7 +13,11 @@ jobs:
       - name: Login
         run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login --username=${{ secrets.DOCKER_USERNAME }} --password-stdin
 
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
       - name: Push apisix dashboard image to Docker Hub
         run:
-          make build-on-dashboard
-          make push-on-dashboard
+          make push-multiarch-dashboard
+

--- a/.github/workflows/dashboard_push_docker_hub.yaml
+++ b/.github/workflows/dashboard_push_docker_hub.yaml
@@ -1,7 +1,5 @@
 name: Push apisix dashboard to Docker image
-on:
-  push:
-    branches: ['release/dashboard**']
+on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/dashboard_push_docker_hub.yaml
+++ b/.github/workflows/dashboard_push_docker_hub.yaml
@@ -1,5 +1,7 @@
 name: Push apisix dashboard to Docker image
-on: [push, pull_request]
+on:
+  push:
+    branches: ['release/dashboard**']
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -11,14 +13,7 @@ jobs:
       - name: Login
         run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login --username=${{ secrets.DOCKER_USERNAME }} --password-stdin
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v1
-
       - name: Push apisix dashboard image to Docker Hub
         run:
-          make push-multiarch-dashboard
-
+          make build-on-dashboard
+          make push-on-dashboard

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@
 default: help
 
 APISIX_VERSION ?= 2.7
-IMAGE_NAME = apache/apisix
+IMAGE_NAME = yiyiyimu/apisix
 IMAGE_TAR_NAME = apache_apisix
 
 APISIX_DASHBOARD_VERSION ?= 2.7

--- a/Makefile
+++ b/Makefile
@@ -38,16 +38,12 @@ build-on-alpine:
 build-on-alpine-local:
 	docker build -t $(IMAGE_NAME):$(APISIX_VERSION)-alpine-local --build-arg APISIX_PATH=${APISIX_PATH} -f ./alpine-local/Dockerfile .
 
-### push-multiarch-on-centos:       Push apache/apisix:xx-centos image
-push-multiarch-on-centos:
-	docker buildx build --push \
-		-t $(IMAGE_NAME):$(APISIX_VERSION)-centos \
-		--platform linux/amd64,linux/arm64 \
-		-f ./centos/Dockerfile .
-	docker buildx build --push \
-		-t $(IMAGE_NAME):latest \
-		--platform linux/amd64,linux/arm64 \
-		-f ./centos/Dockerfile .
+### push-on-centos:       Push apache/apisix:xx-centos image
+# centos not support multiarch since it reply on x86 rpm package
+push-on-centos:
+	docker push $(IMAGE_NAME):$(APISIX_VERSION)-centos
+	docker build -t $(IMAGE_NAME):latest -f ./centos/Dockerfile .
+	docker push $(IMAGE_NAME):latest
 
 ### push-multiarch-on-alpine:       Push apache/apisix:xx-alpine image
 push-multiarch-on-alpine:

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ build-on-alpine:
 build-on-alpine-local:
 	docker build -t $(IMAGE_NAME):$(APISIX_VERSION)-alpine-local --build-arg APISIX_PATH=${APISIX_PATH} -f ./alpine-local/Dockerfile .
 
-### push-on-centos:       Push apache/apisix:xx-centos image
+### push-multiarch-on-centos:       Push apache/apisix:xx-centos image
 push-multiarch-on-centos:
 	docker buildx build --push \
 		-t $(IMAGE_NAME):$(APISIX_VERSION)-centos \
@@ -49,7 +49,7 @@ push-multiarch-on-centos:
 		--platform linux/amd64,linux/arm64 \
 		-f ./centos/Dockerfile .
 
-### push-on-alpine:       Push apache/apisix:xx-alpine image
+### push-multiarch-on-alpine:       Push apache/apisix:xx-alpine image
 push-multiarch-on-alpine:
 	docker buildx build --push \
 		-t $(IMAGE_NAME):$(APISIX_VERSION)-alpine \
@@ -78,11 +78,16 @@ save-alpine-tar:
 build-dashboard:
 	docker build -t $(APISIX_DASHBOARD_IMAGE_NAME):$(APISIX_DASHBOARD_VERSION) -f ./dashboard/Dockerfile .
 
-### push-dashboard:     Push apache/dashboard:tag image
-push-dashboard:
-	docker push $(APISIX_DASHBOARD_IMAGE_NAME):$(APISIX_DASHBOARD_VERSION)
-	docker build -t $(APISIX_DASHBOARD_IMAGE_NAME):latest -f ./dashboard/Dockerfile .
-	docker push $(APISIX_DASHBOARD_IMAGE_NAME):latest
+### push-multiarch-dashboard:     Push apache/dashboard:tag image
+push-multiarch-dashboard:
+	docker buildx build --push \
+		-t $(APISIX_DASHBOARD_IMAGE_NAME):$(APISIX_DASHBOARD_VERSION) \
+		--platform linux/amd64,linux/arm64 \
+		-f ./dashboard/Dockerfile .
+	docker buildx build --push \
+		-t $(APISIX_DASHBOARD_IMAGE_NAME):latest \
+		--platform linux/amd64,linux/arm64 \
+		-f ./dashboard/Dockerfile .
 
 ### save-dashboard-tar:      tar apache/apisix-dashboard:tag image
 save-dashboard-tar:

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@
 default: help
 
 APISIX_VERSION ?= 2.7
-IMAGE_NAME = yiyiyimu/apisix
+IMAGE_NAME = apache/apisix
 IMAGE_TAR_NAME = apache_apisix
 
 APISIX_DASHBOARD_VERSION ?= 2.7
@@ -45,7 +45,7 @@ push-on-centos:
 	docker build -t $(IMAGE_NAME):latest -f ./centos/Dockerfile .
 	docker push $(IMAGE_NAME):latest
 
-### push-multiarch-on-alpine:       Push apache/apisix:xx-alpine image
+### push-on-alpine:       Push apache/apisix:xx-alpine image
 push-multiarch-on-alpine:
 	docker buildx build --push \
 		-t $(IMAGE_NAME):$(APISIX_VERSION)-alpine \
@@ -74,16 +74,11 @@ save-alpine-tar:
 build-dashboard:
 	docker build -t $(APISIX_DASHBOARD_IMAGE_NAME):$(APISIX_DASHBOARD_VERSION) -f ./dashboard/Dockerfile .
 
-### push-multiarch-dashboard:     Push apache/dashboard:tag image
-push-multiarch-dashboard:
-	docker buildx build --push \
-		-t $(APISIX_DASHBOARD_IMAGE_NAME):$(APISIX_DASHBOARD_VERSION) \
-		--platform linux/amd64,linux/arm64 \
-		-f ./dashboard/Dockerfile .
-	docker buildx build --push \
-		-t $(APISIX_DASHBOARD_IMAGE_NAME):latest \
-		--platform linux/amd64,linux/arm64 \
-		-f ./dashboard/Dockerfile .
+### push-dashboard:     Push apache/dashboard:tag image
+push-dashboard:
+	docker push $(APISIX_DASHBOARD_IMAGE_NAME):$(APISIX_DASHBOARD_VERSION)
+	docker build -t $(APISIX_DASHBOARD_IMAGE_NAME):latest -f ./dashboard/Dockerfile .
+	docker push $(APISIX_DASHBOARD_IMAGE_NAME):latest
 
 ### save-dashboard-tar:      tar apache/apisix-dashboard:tag image
 save-dashboard-tar:

--- a/Makefile
+++ b/Makefile
@@ -39,14 +39,22 @@ build-on-alpine-local:
 	docker build -t $(IMAGE_NAME):$(APISIX_VERSION)-alpine-local --build-arg APISIX_PATH=${APISIX_PATH} -f ./alpine-local/Dockerfile .
 
 ### push-on-centos:       Push apache/apisix:xx-centos image
-push-on-centos:
-	docker push $(IMAGE_NAME):$(APISIX_VERSION)-centos
-	docker build -t $(IMAGE_NAME):latest -f ./centos/Dockerfile .
-	docker push $(IMAGE_NAME):latest
+push-multiarch-on-centos:
+	docker buildx build --push \
+		-t $(IMAGE_NAME):$(APISIX_VERSION)-centos \
+		--platform linux/amd64,linux/arm64 \
+		-f ./centos/Dockerfile .
+	docker buildx build --push \
+		-t $(IMAGE_NAME):latest \
+		--platform linux/amd64,linux/arm64 \
+		-f ./centos/Dockerfile .
 
 ### push-on-alpine:       Push apache/apisix:xx-alpine image
-push-on-alpine:
-	docker push $(IMAGE_NAME):$(APISIX_VERSION)-alpine
+push-multiarch-on-alpine:
+	docker buildx build --push \
+		-t $(IMAGE_NAME):$(APISIX_VERSION)-alpine \
+		--platform linux/amd64,linux/arm64 \
+		-f ./alpine/Dockerfile .
 
 ### build-on-alpine-cn:		 Build apache/apisix:xx-alpine image (for chinese)
 build-on-alpine-cn:


### PR DESCRIPTION
Signed-off-by: yiyiyimu <wosoyoung@gmail.com>

Try to build with Github Actions on forked repo and successfully build apisix image in amd64+arm64: https://hub.docker.com/r/yiyiyimu/apisix/tags?page=1&ordering=last_updated

can not build centos multiarch image since it rely on x86 rpm. ref: https://github.com/Yiyiyimu/apisix-docker/runs/3053744032?check_suite_focus=true
can not build dashboard multiarch image since yarn build failed. ref: https://github.com/Yiyiyimu/apisix-docker/runs/3053802787?check_suite_focus=true