### PR TITLE
ci: Add PCRE package for dependency installation

### DIFF
--- a/alpine-local/Dockerfile
+++ b/alpine-local/Dockerfile
@@ -14,6 +14,8 @@ RUN set -x \
     pkgconfig \
     cmake \
     git \
+    pcre \
+    pcre-dev \
     && cd apisix \
     && make deps \
     && cp -v bin/apisix /usr/bin/ \


### PR DESCRIPTION
The `authz-casbin` plugin requires PCRE package installed and hence it failed the chaos test. This PR adds the package as dependency.
([Context](https://github.com/apache/apisix/pull/4710#discussion_r680569232))