### PR TITLE
chore: use the correct prometheus port for docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ You can refer to [the docker-compose example](docs/en/latest/example.md) for mor
 
 ```shell
 $ make build-all-in-one
-$ docker run -v `pwd`/all-in-one/apisix/config.yaml:/usr/local/apisix/conf/config.yaml -p 9080:9080 -p 2379:2379 -d apache/apisix:whole
+$ docker run -v `pwd`/all-in-one/apisix/config.yaml:/usr/local/apisix/conf/config.yaml -p 9080:9080 -p 9091:9091 -p 2379:2379 -d apache/apisix:whole
 ```
 
 * All in one Docker container for Apache apisix-dashboard
@@ -73,11 +73,11 @@ $ docker run -v `pwd`/all-in-one/apisix/config.yaml:/usr/local/apisix/conf/confi
 
 ```shell
 $ make build-dashboard
-$ docker run -v `pwd`/all-in-one/apisix/config.yaml:/usr/local/apisix/conf/config.yaml -v `pwd`/all-in-one/apisix-dashboard/conf.yaml:/usr/local/apisix-dashboard/conf/conf.yaml -p 9080:9080 -p 2379:2379 -p 9000:9000 -d apache/apisix-dashboard:whole
+$ docker run -v `pwd`/all-in-one/apisix/config.yaml:/usr/local/apisix/conf/config.yaml -v `pwd`/all-in-one/apisix-dashboard/conf.yaml:/usr/local/apisix-dashboard/conf/conf.yaml -p 9080:9080 -p 9091:9091 -p 2379:2379 -p 9000:9000 -d apache/apisix-dashboard:whole
 ```
 
 Tips: If there is a port conflict, please modify the host port through `docker run -p`, e.g.
 
 ```shell
-$ docker run -v `pwd`/all-in-one/apisix/config.yaml:/usr/local/apisix/conf/config.yaml -v `pwd`/all-in-one/apisix-dashboard/conf.yaml:/usr/local/apisix-dashboard/conf/conf.yaml -p 19080:9080 -p 12379:2379 -p 19000:9000 -d apache/apisix-dashboard:whole
+$ docker run -v `pwd`/all-in-one/apisix/config.yaml:/usr/local/apisix/conf/config.yaml -v `pwd`/all-in-one/apisix-dashboard/conf.yaml:/usr/local/apisix-dashboard/conf/conf.yaml -p 19080:9080 -p 19091:9091 -p 12379:2379 -p 19000:9000 -d apache/apisix-dashboard:whole
 ```

--- a/README.md
+++ b/README.md
@@ -81,3 +81,13 @@ Tips: If there is a port conflict, please modify the host port through `docker r
 ```shell
 $ docker run -v `pwd`/all-in-one/apisix/config.yaml:/usr/local/apisix/conf/config.yaml -v `pwd`/all-in-one/apisix-dashboard/conf.yaml:/usr/local/apisix-dashboard/conf/conf.yaml -p 19080:9080 -p 19091:9091 -p 12379:2379 -p 19000:9000 -d apache/apisix-dashboard:whole
 ```
+
+**Note**: Apache APISIX expose prometheus metrics port on 9091, and you need to expose it to `0.0.0.0` instead of the default `127.0.0.1` to make it accessible outside docker. You could achieve it with adding the following to your `config.yaml`.
+
+```shell
+plugin_attr:
+  prometheus:
+    export_addr:
+      ip: "0.0.0.0"
+      port: 9091
+```

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ $ docker run -v `pwd`/all-in-one/apisix/config.yaml:/usr/local/apisix/conf/confi
 ```
 
 ### Note
+
 Apache APISIX expose prometheus metrics port on 9091, and you need to expose it to `0.0.0.0` instead of the default `127.0.0.1` to make it accessible outside docker. You could achieve it with adding the following to your `config.yaml`.
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ Tips: If there is a port conflict, please modify the host port through `docker r
 $ docker run -v `pwd`/all-in-one/apisix/config.yaml:/usr/local/apisix/conf/config.yaml -v `pwd`/all-in-one/apisix-dashboard/conf.yaml:/usr/local/apisix-dashboard/conf/conf.yaml -p 19080:9080 -p 19091:9091 -p 12379:2379 -p 19000:9000 -d apache/apisix-dashboard:whole
 ```
 
-**Note**: Apache APISIX expose prometheus metrics port on 9091, and you need to expose it to `0.0.0.0` instead of the default `127.0.0.1` to make it accessible outside docker. You could achieve it with adding the following to your `config.yaml`.
+### Note
+Apache APISIX expose prometheus metrics port on 9091, and you need to expose it to `0.0.0.0` instead of the default `127.0.0.1` to make it accessible outside docker. You could achieve it with adding the following to your `config.yaml`.
 
 ```shell
 plugin_attr:

--- a/all-in-one/apisix-dashboard/conf.yaml
+++ b/all-in-one/apisix-dashboard/conf.yaml
@@ -26,3 +26,9 @@ authentication:
       password: admin
     - username: user
       password: user
+
+plugin_attr:
+  prometheus:
+    export_addr:
+      ip: "0.0.0.0"
+      port: 9091

--- a/all-in-one/apisix/config.yaml
+++ b/all-in-one/apisix/config.yaml
@@ -4,3 +4,9 @@ apisix:
 
   allow_admin:                  # http://nginx.org/en/docs/http/ngx_http_access_module.html#allow
     - 0.0.0.0/0              # We need to restrict ip access rules for security. 0.0.0.0/0 is for test.
+
+plugin_attr:
+  prometheus:
+    export_addr:
+      ip: "0.0.0.0"
+      port: 9091

--- a/compose/docker-compose.yaml
+++ b/compose/docker-compose.yaml
@@ -11,6 +11,7 @@ services:
       - etcd
     ports:
       - "9080:9080/tcp"
+      - "9091:9091/tcp"
       - "9443:9443/tcp"
     networks:
       - apisix

--- a/docs/en/latest/manual.md
+++ b/docs/en/latest/manual.md
@@ -66,6 +66,7 @@ docker run --name test-api-gateway \
  -v `pwd`/example/apisix_conf/config.yaml:/usr/local/apisix/conf/config.yaml \
  -v `pwd`/example/apisix_log:/usr/local/apisix/logs  \
  -p 9080:9080 \
+ -p 9091:9091  \
  -p 9443:9443 \
  --network apisix \
  --ip 172.18.5.11 \

--- a/example/apisix_conf/config.yaml
+++ b/example/apisix_conf/config.yaml
@@ -19,3 +19,9 @@ etcd:
     - "http://etcd:2379"     # multiple etcd address
   prefix: "/apisix"               # apisix configurations prefix
   timeout: 30                     # 30 seconds
+
+plugin_attr:
+  prometheus:
+    export_addr:
+      ip: "0.0.0.0"
+      port: 9091

--- a/example/docker-compose-alpine.yml
+++ b/example/docker-compose-alpine.yml
@@ -15,6 +15,7 @@ services:
       - etcd
     ports:
       - "9080:9080/tcp"
+      - "9091:9091/tcp"
       - "9443:9443/tcp"
     networks:
       apisix:

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       apisix:
 
   apisix:
-    image: apache/apisix:2.6-alpine
+    image: apache/apisix:2.7-alpine
     restart: always
     volumes:
       - ./apisix_log:/usr/local/apisix/logs
@@ -22,6 +22,7 @@ services:
     ##network_mode: host
     ports:
       - "9080:9080/tcp"
+      - "9091:9091/tcp"
       - "9443:9443/tcp"
     networks:
       apisix:

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       apisix:
 
   apisix:
-    image: apache/apisix:2.7-alpine
+    image: apache/apisix:2.6-alpine
     restart: always
     volumes:
       - ./apisix_log:/usr/local/apisix/logs


### PR DESCRIPTION
Signed-off-by: yiyiyimu <wosoyoung@gmail.com>

fix #204 

manually tested