### PR TITLE
fix(etcd): fix etcd startup report permission issue

### DIFF
--- a/example/docker-compose-alpine.yml
+++ b/example/docker-compose-alpine.yml
@@ -22,10 +22,9 @@ services:
 
   etcd:
     image: bitnami/etcd:3.4.9
-    user: root
     restart: always
     volumes:
-      - ./etcd_data:/etcd_data
+      - etcd_data:/bitnami/etcd
     environment:
       ETCD_DATA_DIR: /etcd_data
       ETCD_ENABLE_V2: "true"
@@ -64,3 +63,7 @@ services:
 networks:
   apisix:
     driver: bridge
+
+volumes:
+  etcd_data:
+    driver: local

--- a/example/docker-compose-alpine.yml
+++ b/example/docker-compose-alpine.yml
@@ -67,3 +67,4 @@ networks:
 volumes:
   etcd_data:
     driver: local
+

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -29,10 +29,9 @@ services:
 
   etcd:
     image: bitnami/etcd:3.4.15
-    user: root
     restart: always
     volumes:
-      - ./etcd_data:/bitnami/etcd
+      - etcd_data:/bitnami/etcd
     environment:
       ETCD_ENABLE_V2: "true"
       ALLOW_NONE_AUTHENTICATION: "yes"
@@ -70,3 +69,7 @@ services:
 networks:
   apisix:
     driver: bridge
+
+volumes:
+  etcd_data:
+    driver: local

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -73,3 +73,4 @@ networks:
 volumes:
   etcd_data:
     driver: local
+


### PR DESCRIPTION
#174 Etcd Startup still has permissions issues.

```
# test
os: buster
docker: 20.10.8
```

Signed-off-by: ysicing <i@ysicing.me>

