### PR TITLE
feat: Add docker-compose config for arm64

### DIFF
--- a/example/docker-compose-arm64.yml
+++ b/example/docker-compose-arm64.yml
@@ -1,0 +1,62 @@
+version: "3"
+
+services:
+  apisix:
+    image: apache/apisix:2.9-alpine
+    restart: always
+    volumes:
+      - ./apisix_log:/usr/local/apisix/logs
+      - ./apisix_conf/config.yaml:/usr/local/apisix/conf/config.yaml:ro
+    depends_on:
+      - etcd
+    ports:
+      - "9080:9080/tcp"
+      - "9091:9091/tcp"
+      - "9443:9443/tcp"
+    networks:
+      apisix:
+
+  etcd:
+    image: rancher/coreos-etcd:v3.4.13-arm64
+    user: root
+    restart: always
+    volumes:
+      - ./etcd_data:/etcd-data
+    environment:
+      ETCD_UNSUPPORTED_ARCH: "arm64"
+      ETCD_ENABLE_V2: "true"
+      ALLOW_NONE_AUTHENTICATION: "yes"
+      ETCD_ADVERTISE_CLIENT_URLS: "http://0.0.0.0:2379"
+      ETCD_LISTEN_CLIENT_URLS: "http://0.0.0.0:2379"
+    ports:
+      - "2379:2379/tcp"
+    networks:
+      apisix:
+
+  web1:
+    image: nginx:1.19.10-alpine
+    restart: always
+    volumes:
+      - ./upstream/web1.conf:/etc/nginx/nginx.conf
+    ports:
+      - "9081:80/tcp"
+    environment:
+      - NGINX_PORT=80
+    networks:
+      apisix:
+
+  web2:
+    image: nginx:1.19.10-alpine
+    restart: always
+    volumes:
+      - ./upstream/web2.conf:/etc/nginx/nginx.conf
+    ports:
+      - "9082:80/tcp"
+    environment:
+      - NGINX_PORT=80
+    networks:
+      apisix:
+
+networks:
+  apisix:
+    driver: bridge


### PR DESCRIPTION
Signed-off-by: imjoey <majunjie@apache.org>

This PR is going to add the docker-compose configurations for ARM64. Since apisix-dashboard has no arm64 image yet, so only apisix is included. 

The OS for testing is shown as below:
![7091631084298_ pic copy](https://user-images.githubusercontent.com/2542401/132491712-42d0b5b3-4e3d-4fd5-a821-9d4024dbf3da.png)

Here is the test result:
![image](https://user-images.githubusercontent.com/2542401/132491463-feb4f181-a503-4e6c-9bc2-d96b23820e0f.png)


Actually, we do need a CI for continuous testing. Still looking for proper CI resources with ARM64.
