### PR TITLE
feat: Add openldap-devel dependency for the support of the plugin ldap-auth

### DIFF
--- a/all-in-one/apisix/Dockerfile
+++ b/all-in-one/apisix/Dockerfile
@@ -21,6 +21,7 @@ RUN set -x \
     git \
     pcre \
     pcre-dev \
+    openldap-dev \
     && mkdir ~/.luarocks \
     && luarocks config variables.OPENSSL_LIBDIR /usr/local/openresty/openssl/lib \
     && luarocks config variables.OPENSSL_INCDIR /usr/local/openresty/openssl/include \
@@ -49,7 +50,7 @@ ARG ENABLE_PROXY
 # add runtime for Apache APISIX
 RUN set -x \
     && (test "${ENABLE_PROXY}" != "true" || /bin/sed -i 's,http://dl-cdn.alpinelinux.org,https://mirrors.aliyun.com,g' /etc/apk/repositories) \
-    && apk add --no-cache bash libstdc++ curl
+    && apk add --no-cache bash libstdc++ curl openldap-dev
 
 WORKDIR /usr/local/apisix
 

--- a/alpine-dev/Dockerfile
+++ b/alpine-dev/Dockerfile
@@ -14,6 +14,7 @@ RUN set -x \
     git \
     pcre \
     pcre-dev \
+    openldap-dev \
     && mkdir ~/.luarocks \
     && luarocks config variables.OPENSSL_LIBDIR /usr/local/openresty/openssl/lib \
     && luarocks config variables.OPENSSL_INCDIR /usr/local/openresty/openssl/include \
@@ -28,7 +29,7 @@ ARG ENABLE_PROXY
 # add runtime for Apache APISIX
 RUN set -x \
     && (test "${ENABLE_PROXY}" != "true" || /bin/sed -i 's,http://dl-cdn.alpinelinux.org,https://mirrors.aliyun.com,g' /etc/apk/repositories) \
-    && apk add --no-cache bash libstdc++ curl tzdata
+    && apk add --no-cache bash libstdc++ curl tzdata openldap-dev
 
 WORKDIR /usr/local/apisix
 

--- a/alpine-local/Dockerfile
+++ b/alpine-local/Dockerfile
@@ -16,6 +16,7 @@ RUN set -x \
     git \
     pcre \
     pcre-dev \
+    openldap-dev \
     && cd apisix \
     && make deps \
     && cp -v bin/apisix /usr/bin/ \
@@ -28,7 +29,7 @@ ARG ENABLE_PROXY
 # add runtime for Apache APISIX
 RUN set -x \
     && (test "${ENABLE_PROXY}" != "true" || /bin/sed -i 's,http://dl-cdn.alpinelinux.org,https://mirrors.aliyun.com,g' /etc/apk/repositories) \
-    && apk add --no-cache bash libstdc++ curl tzdata
+    && apk add --no-cache bash libstdc++ curl tzdata openldap-dev
 
 WORKDIR /usr/local/apisix
 

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -17,6 +17,7 @@ RUN set -x \
     git \
     pcre \
     pcre-dev \
+    openldap-dev \
     && mkdir ~/.luarocks \
     && luarocks config variables.OPENSSL_LIBDIR /usr/local/openresty/openssl/lib \
     && luarocks config variables.OPENSSL_INCDIR /usr/local/openresty/openssl/include \

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -32,7 +32,7 @@ ARG ENABLE_PROXY
 # add runtime for Apache APISIX
 RUN set -x \
     && (test "${ENABLE_PROXY}" != "true" || /bin/sed -i 's,http://dl-cdn.alpinelinux.org,https://mirrors.aliyun.com,g' /etc/apk/repositories) \
-    && apk add --no-cache bash libstdc++ curl tzdata
+    && apk add --no-cache bash libstdc++ curl tzdata openldap-dev
 
 WORKDIR /usr/local/apisix
 

--- a/centos/Dockerfile
+++ b/centos/Dockerfile
@@ -5,7 +5,7 @@ LABEL apisix_version="${APISIX_VERSION}"
 
 RUN yum -y install yum-utils\
 	&& yum-config-manager --add-repo https://openresty.org/package/centos/openresty.repo \
-	&& yum install -y pcre openresty which tzdata \
+	&& yum install -y pcre openresty which tzdata openldap-devel \
 	&& yum install -y https://github.com/apache/apisix/releases/download/$APISIX_VERSION/apisix-$APISIX_VERSION-0.el7.x86_64.rpm \
 	&& yum clean all \
 	&& sed -i 's/PASS_MAX_DAYS\t99999/PASS_MAX_DAYS\t60/g' /etc/login.defs


### PR DESCRIPTION
Hi,
I propose this PR to include the support of `openldap-devel` for the `ldap-auth` plugin 
Related to : #https://github.com/apache/apisix/pull/3894 