### PR TITLE
docs: use make instead of docker

### DIFF
--- a/docs/en/latest/build.md
+++ b/docs/en/latest/build.md
@@ -29,11 +29,12 @@ title: Build an image from the source codes
 ```
 # Assign Apache release version number to variable `APISIX_VERSION`, for example: 2.2. The latest version can be find at `https://github.com/apache/apisix/releases`
 
-APISIX_VERSION=2.2
-docker build -t apisix:${APISIX_VERSION}-alpine --build-arg APISIX_VERSION=${APISIX_VERSION} -f alpine/Dockerfile alpine
+export APISIX_VERSION=2.9
+make build-on-alpine
 ```
 
 2. install master branch version, which has latest code(ONLY for the developer's convenience):
 ```
-docker build -t apisix:master-alpine -f alpine/Dockerfile alpine
+export APISIX_VERSION=master
+make build-on-alpine
 ```


### PR DESCRIPTION
1. update APISIX version to `2.9`
2. use make instead of docker cmd in docs, more elegant

Signed-off-by: leslie tsang <leslie.tsang@icloud.com>