### PR TITLE
feat: bump APISIX Dashboard to 2.10

### DIFF
--- a/.github/workflows/dashboard-docker-test.yaml
+++ b/.github/workflows/dashboard-docker-test.yaml
@@ -13,7 +13,7 @@ jobs:
     name: build dashboard & test
     runs-on: ubuntu-latest
     env:
-      APISIX_DASHBOARD_TAG: 2.10
+      APISIX_DASHBOARD_TAG: "2.10"
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/dashboard-docker-test.yaml
+++ b/.github/workflows/dashboard-docker-test.yaml
@@ -13,7 +13,7 @@ jobs:
     name: build dashboard & test
     runs-on: ubuntu-latest
     env:
-      APISIX_DASHBOARD_TAG: 2.9.0
+      APISIX_DASHBOARD_TAG: 2.10
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/dashboard_push_docker_hub.yaml
+++ b/.github/workflows/dashboard_push_docker_hub.yaml
@@ -15,6 +15,9 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
 
       - name: Push apisix dashboard image to Docker Hub
         run: |

--- a/.github/workflows/dashboard_push_docker_hub.yaml
+++ b/.github/workflows/dashboard_push_docker_hub.yaml
@@ -21,5 +21,4 @@ jobs:
 
       - name: Push apisix dashboard image to Docker Hub
         run: |
-          make build-dashboard
-          make push-dashboard
+          make push-multiarch-dashbaord

--- a/.github/workflows/dashboard_push_docker_hub.yaml
+++ b/.github/workflows/dashboard_push_docker_hub.yaml
@@ -16,6 +16,9 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 

--- a/.github/workflows/dashboard_push_docker_hub.yaml
+++ b/.github/workflows/dashboard_push_docker_hub.yaml
@@ -1,7 +1,7 @@
 name: Push apisix dashboard to Docker image
 on:
   push:
-    branches: []
+    branches: ['release/apisix-dashboard**']
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,21 @@ push-dashboard:
 	@$(call func_echo_success_status, "$@ -> [ Done ]")
 
 
+### push-multiarch-dashbaord : Build and push multiarch apache/dashboard:tag image
+.PHONY: push-multiarch-dashbaord
+push-multiarch-dashbaord:
+	@$(call func_echo_status, "$@ -> [ Start ]")
+	$(ENV_DOCKER) buildx build --push \
+		-t $(APISIX_DASHBOARD_IMAGE_NAME):$(APISIX_DASHBOARD_VERSION) \
+		--platform linux/amd64,linux/arm64 \
+		-f ./dashboard/Dockerfile .
+	$(ENV_DOCKER) buildx build --push \
+		-t $(APISIX_DASHBOARD_IMAGE_NAME):latest \
+		--platform linux/amd64,linux/arm64 \
+		-f ./dashboard/Dockerfile .
+	@$(call func_echo_success_status, "$@ -> [ Done ]")
+
+
 ### save-dashboard-tar : tar apache/apisix-dashboard:tag image
 .PHONY: save-dashboard-tar
 save-dashboard-tar:

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ APISIX_VERSION ?= 2.11.0
 IMAGE_NAME = apache/apisix
 IMAGE_TAR_NAME = apache_apisix
 
-APISIX_DASHBOARD_VERSION ?= 2.9.0
+APISIX_DASHBOARD_VERSION ?= 2.10
 APISIX_DASHBOARD_IMAGE_NAME = apache/apisix-dashboard
 APISIX_DASHBOARD_IMAGE_TAR_NAME = apache_apisix_dashboard
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ apache/apisix:whole
 
 * All in one Docker container for Apache apisix-dashboard
 
-**The latest version of `apisix-dashboard` is 2.9 and can be used with APISIX 2.10.**
+**The latest version of `apisix-dashboard` is 2.10 and can be used with APISIX 2.11.**
 
 ```sh
 make build-dashboard

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -16,7 +16,7 @@
 #
 FROM alpine:latest as pre-build
 
-ARG APISIX_DASHBOARD_VERSION=release/2.9.0
+ARG APISIX_DASHBOARD_VERSION=release/2.10
 
 RUN set -x \
     && apk add --no-cache --virtual .builddeps git \

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+ARG BUILDPLATFORM=amd64
+
 FROM --platform=$BUILDPLATFORM alpine:latest as pre-build
 
 ARG APISIX_DASHBOARD_VERSION=release/2.10
@@ -69,4 +71,4 @@ RUN mkdir logs
 
 EXPOSE 9000
 
-CMD [ "/usr/local/apisix-dashboard/manager-api" ]
+ENTRYPOINT [ "/usr/local/apisix-dashboard/manager-api" ]

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM alpine:latest as pre-build
+FROM --platform=$BUILDPLATFORM alpine:latest as pre-build
 
 ARG APISIX_DASHBOARD_VERSION=release/2.10
 
@@ -24,7 +24,7 @@ RUN set -x \
     && cd /usr/local/apisix-dashboard && git clean -Xdf \
     && rm -f ./.githash && git log --pretty=format:"%h" -1 > ./.githash
 
-FROM golang:1.14 as api-builder
+FROM --platform=$BUILDPLATFORM golang:1.14 as api-builder
 
 ARG ENABLE_PROXY=false
 
@@ -32,11 +32,14 @@ WORKDIR /usr/local/apisix-dashboard
 
 COPY --from=pre-build /usr/local/apisix-dashboard .
 
+ARG TARGETOS
+ARG TARGETARCH
+
 RUN if [ "$ENABLE_PROXY" = "true" ] ; then go env -w GOPROXY=https://goproxy.io,direct ; fi \
     && go env -w GO111MODULE=on \
-    && CGO_ENABLED=0 ./api/build.sh
+    && CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} ./api/build.sh
 
-FROM node:14-alpine as fe-builder
+FROM --platform=$BUILDPLATFORM node:14-alpine as fe-builder
 
 ARG ENABLE_PROXY=false
 

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   apisix-dashboard:
-    image: apache/apisix-dashboard:2.10
+    image: apache/apisix-dashboard:2.9.0
     restart: always
     volumes:
     - ./dashboard_conf/conf.yaml:/usr/local/apisix-dashboard/conf/conf.yaml
@@ -12,7 +12,7 @@ services:
       apisix:
 
   apisix:
-    image: apache/apisix:2.11.0-alpine
+    image: apache/apisix:2.10.0-alpine
     restart: always
     volumes:
       - ./apisix_log:/usr/local/apisix/logs

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   apisix-dashboard:
-    image: apache/apisix-dashboard:2.9.0
+    image: apache/apisix-dashboard:2.10
     restart: always
     volumes:
     - ./dashboard_conf/conf.yaml:/usr/local/apisix-dashboard/conf/conf.yaml
@@ -12,7 +12,7 @@ services:
       apisix:
 
   apisix:
-    image: apache/apisix:2.10.0-alpine
+    image: apache/apisix:2.11.0-alpine
     restart: always
     volumes:
       - ./apisix_log:/usr/local/apisix/logs


### PR DESCRIPTION
Upgrade the latest version of APISIX Dashbaord 2.10 while supporting multi-architecture build and push.