### PR TITLE
feat: non-root docker images

### DIFF
--- a/all-in-one/apisix/Dockerfile
+++ b/all-in-one/apisix/Dockerfile
@@ -57,11 +57,12 @@ COPY --from=production-stage /usr/bin/apisix /usr/bin/apisix
 
 COPY --from=etcd-stage /tmp/etcd/etcd /usr/bin/etcd
 COPY --from=etcd-stage /tmp/etcd/etcdctl /usr/bin/etcdctl
+RUN chown -R 1001:1001 /usr/local/apisix
 
 ENV PATH=$PATH:/usr/local/openresty/luajit/bin:/usr/local/openresty/nginx/sbin:/usr/local/openresty/bin
 
 EXPOSE 9080 9443 2379 2380
-
+USER 1001
 CMD ["sh", "-c", "(nohup etcd >/tmp/etcd.log 2>&1 &) && sleep 10 && /usr/bin/apisix init && /usr/bin/apisix init_etcd && /usr/local/openresty/bin/openresty -p /usr/local/apisix -g 'daemon off;'"]
 
 STOPSIGNAL SIGQUIT

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -26,6 +26,7 @@ RUN set -x \
     && apk del .builddeps build-base make unzip
 
 FROM alpine:3.13 AS last-stage
+
 ARG ENABLE_PROXY
 # add runtime for Apache APISIX
 RUN set -x \
@@ -33,6 +34,7 @@ RUN set -x \
     && apk add --no-cache bash libstdc++ curl tzdata openldap-dev
 
 WORKDIR /usr/local/apisix
+
 COPY --from=production-stage /usr/local/openresty/ /usr/local/openresty/
 COPY --from=production-stage /usr/local/apisix/ /usr/local/apisix/
 COPY --from=production-stage /usr/bin/apisix /usr/bin/apisix
@@ -43,9 +45,10 @@ RUN ln -sf /dev/stdout /usr/local/apisix/logs/access.log \
 
 RUN chown -R 1001:1001 /usr/local/apisix
 ENV PATH=$PATH:/usr/local/openresty/luajit/bin:/usr/local/openresty/nginx/sbin:/usr/local/openresty/bin
-USER 1001
+
 EXPOSE 9080 9443
 
+USER 1001
 CMD ["sh", "-c", "/usr/bin/apisix init && /usr/bin/apisix init_etcd && /usr/local/openresty/bin/openresty -p /usr/local/apisix -g 'daemon off;'"]
 
 STOPSIGNAL SIGQUIT

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -26,7 +26,6 @@ RUN set -x \
     && apk del .builddeps build-base make unzip
 
 FROM alpine:3.13 AS last-stage
-
 ARG ENABLE_PROXY
 # add runtime for Apache APISIX
 RUN set -x \
@@ -34,7 +33,6 @@ RUN set -x \
     && apk add --no-cache bash libstdc++ curl tzdata openldap-dev
 
 WORKDIR /usr/local/apisix
-
 COPY --from=production-stage /usr/local/openresty/ /usr/local/openresty/
 COPY --from=production-stage /usr/local/apisix/ /usr/local/apisix/
 COPY --from=production-stage /usr/bin/apisix /usr/bin/apisix
@@ -43,8 +41,9 @@ COPY --from=production-stage /usr/bin/apisix /usr/bin/apisix
 RUN ln -sf /dev/stdout /usr/local/apisix/logs/access.log \
     && ln -sf /dev/stderr /usr/local/apisix/logs/error.log
 
+RUN chown -R 1001:1001 /usr/local/apisix
 ENV PATH=$PATH:/usr/local/openresty/luajit/bin:/usr/local/openresty/nginx/sbin:/usr/local/openresty/bin
-
+USER 1001
 EXPOSE 9080 9443
 
 CMD ["sh", "-c", "/usr/bin/apisix init && /usr/bin/apisix init_etcd && /usr/local/openresty/bin/openresty -p /usr/local/apisix -g 'daemon off;'"]

--- a/centos/Dockerfile
+++ b/centos/Dockerfile
@@ -9,11 +9,12 @@ RUN yum install -y https://repos.apiseven.com/packages/centos/apache-apisix-repo
 	&& sed -i 's/PASS_MAX_DAYS\t99999/PASS_MAX_DAYS\t60/g' /etc/login.defs
 
 WORKDIR /usr/local/apisix
+RUN chown -R 1001:1001 /usr/local/apisix
 
 # forward request and error logs to docker log collector
 RUN ln -sf /dev/stdout /usr/local/apisix/logs/access.log \
     && ln -sf /dev/stderr /usr/local/apisix/logs/error.log
-
+USER 1001
 EXPOSE 9080 9443
 
 CMD ["sh", "-c", "/usr/bin/apisix init && /usr/bin/apisix init_etcd && /usr/local/openresty/bin/openresty -p /usr/local/apisix -g 'daemon off;'"]

--- a/centos/Dockerfile
+++ b/centos/Dockerfile
@@ -14,8 +14,8 @@ RUN chown -R 1001:1001 /usr/local/apisix
 # forward request and error logs to docker log collector
 RUN ln -sf /dev/stdout /usr/local/apisix/logs/access.log \
     && ln -sf /dev/stderr /usr/local/apisix/logs/error.log
-USER 1001
 EXPOSE 9080 9443
 
+USER 1001
 CMD ["sh", "-c", "/usr/bin/apisix init && /usr/bin/apisix init_etcd && /usr/local/openresty/bin/openresty -p /usr/local/apisix -g 'daemon off;'"]
 


### PR DESCRIPTION
Add the ability to run the alpine, centos and all-in-one docker images with a non-root user.
For development purposes,  dev/local images can still run with root privileges by default.