### PR TITLE
fix: rollback the docker image used in chaos test

### DIFF
--- a/alpine-local/Dockerfile
+++ b/alpine-local/Dockerfile
@@ -1,6 +1,6 @@
 ARG ENABLE_PROXY=false
 
-FROM api7/apisix-base:1.19.3.2.2 AS production-stage
+FROM openresty/openresty:1.19.3.2-alpine-fat AS production-stage
 
 ARG ENABLE_PROXY
 ARG APISIX_PATH


### PR DESCRIPTION
The apisix-base version is not up-to-date. So we fall back to use
OpenResty to let CI pass.
See https://github.com/apache/apisix/pull/5943.

TODO: use CI to provide a latest apisix-base image.