### PR TITLE
feat: update apisix-base version to 1.19.9.1.2

### DIFF
--- a/alpine-dev/Dockerfile
+++ b/alpine-dev/Dockerfile
@@ -17,7 +17,7 @@
 
 ARG ENABLE_PROXY=false
 
-FROM api7/apisix-base:1.19.3.2.2 AS production-stage
+FROM api7/apisix-base:1.19.9.1.2 AS production-stage
 
 ARG ENABLE_PROXY
 RUN set -x \


### PR DESCRIPTION
Please don‘t merge until `api7/apisix-base:1.19.9.1.2` has been pushed.