### PR TITLE
chore: update apisix image version in example

### DIFF
--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       apisix:
 
   apisix:
-    image: apache/apisix:2.11.0-alpine
+    image: apache/apisix:2.12.0-alpine
     restart: always
     volumes:
       - ./apisix_log:/usr/local/apisix/logs


### PR DESCRIPTION
from 2.11.0-alpine to 2.12.0-alpine