### PR TITLE
ci(apisix-dev): timed sync apisix-dev image

### DIFF
--- a/.github/workflows/apisix_dev_push_docker_hub.yaml
+++ b/.github/workflows/apisix_dev_push_docker_hub.yaml
@@ -1,0 +1,31 @@
+name: Build and Push apisix-dev to Docker image
+
+
+on:
+  schedule:
+    # UTC 0:00 AM (See https://pubs.opengroup.org/onlinepubs/9699919799/utilities/crontab.html#tag_20_25_07)
+    - cron: "0 0 * * *"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Push apisix image to Docker Hub
+        run: |
+          make push-multiarch-dev-on-alpine

--- a/.github/workflows/apisix_dev_push_docker_hub.yaml
+++ b/.github/workflows/apisix_dev_push_docker_hub.yaml
@@ -1,4 +1,4 @@
-name: Build and Push apisix-dev to Docker image
+name: Build and Push apisix-dev to Docker DockerHub
 
 
 on:

--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,17 @@ push-multiarch-on-alpine:
 	@$(call func_echo_success_status, "$@ -> [ Done ]")
 
 
+### push-on-alpine : Push apache/apisix:dev image
+.PHONY: push-multiarch-dev-on-alpine
+push-multiarch-dev-on-alpine:
+	@$(call func_echo_status, "$@ -> [ Start ]")
+	$(ENV_DOCKER) buildx build --push \
+		-t $(IMAGE_NAME):dev \
+		--platform linux/amd64,linux/arm64 \
+		-f ./alpine-dev/Dockerfile .
+	@$(call func_echo_success_status, "$@ -> [ Done ]")
+
+
 ### build-on-alpine-cn : Build apache/apisix:xx-alpine image (for chinese)
 .PHONY: build-on-alpine-cn
 build-on-alpine-cn:

--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ apache/apisix-dashboard:whole
 
 ### Note
 
+**Prometheus**
+
 Apache APISIX expose prometheus metrics port on 9091, and you need to expose it to `0.0.0.0` instead of the default `127.0.0.1` to make it accessible outside docker. You could achieve it with adding the following to your `config.yaml`.
 
 ```shell
@@ -128,4 +130,12 @@ plugin_attr:
     export_addr:
       ip: "0.0.0.0"
       port: 9091
+```
+
+**APISIX-Dev Image**
+
+At `0:00 UTC` every day, the APISIX `master` code will be automatically built and synchronized to the Docker Hub repository. You can pull the latest master branch image in the following ways.
+
+```bash
+docker pull apache/apisix:dev
 ```


### PR DESCRIPTION
This CI will build the APISIX master branch code into the docker hub repository at 0:00 UTC every day, so that developers can experience and test the new features in a timely manner.