### PR TITLE
chore: typo error, change dashbaord to dashboard

### DIFF
--- a/.github/workflows/dashboard_push_docker_hub.yaml
+++ b/.github/workflows/dashboard_push_docker_hub.yaml
@@ -24,4 +24,4 @@ jobs:
 
       - name: Push apisix dashboard image to Docker Hub
         run: |
-          make push-multiarch-dashbaord
+          make push-multiarch-dashboard

--- a/Makefile
+++ b/Makefile
@@ -185,9 +185,9 @@ build-dashboard-alpine:
 	@$(call func_echo_success_status, "$@ -> [ Done ]")
 
 
-### push-multiarch-dashbaord : Build and push multiarch apache/dashboard:tag image
-.PHONY: push-multiarch-dashbaord
-push-multiarch-dashbaord:
+### push-multiarch-dashboard : Build and push multiarch apache/dashboard:tag image
+.PHONY: push-multiarch-dashboard
+push-multiarch-dashboard:
 	@$(call func_echo_status, "$@ -> [ Start ]")
 	$(ENV_DOCKER) buildx build --push \
 		-t $(APISIX_DASHBOARD_IMAGE_NAME):$(APISIX_DASHBOARD_VERSION)-alpine \


### PR DESCRIPTION
# Issue description

I found the typo error(maybe).
Reproduction:

run make help;
and find the command make push-multiarch-dashbaord (please notice the dashbaord)

# Do what

Change all **dashbaord** to **dashboard**.

# fix issues:

#301 