### PR TITLE
Add doc for docker-compose, makefile commands, and images in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ This repo includes:
 
 ## How To Build Images
 
-**Note**: Docker images are not official ASF releases but provided for convenience. Recommended usage is always to build the source.
+**Note**: Docker images are not official ASF releases but provided for convenience. Recommended usage is always to build the source. \
+**Note**: The master branch is for the version of Apache APISIX 2.x. If you need a previous version, please build from the [v1.x](https://github.com/apache/apisix-docker/releases/tag/v1.x) tag.
 
 The repo contains the following images:
 
@@ -17,8 +18,6 @@ The repo contains the following images:
 - `/dashboard` contains two docker files - `Dockerfile.alpine` and `Dockerfile.centos`, which build APISIX dashboard on alpine and centos respectively.
 
 You can build these images as follows:
-
-**Note**: The master branch is for the version of Apache APISIX 2.x. If you need a previous version, please build from the [v1.x](https://github.com/apache/apisix-docker/releases/tag/v1.x) tag.
 
 ### Build an image from source
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## Summary
-This repo hosts docker images for APISIX, APISIX dashboard, Prometheus and Grafana (which emit metrics of APISIX). It also includes useful commands to use, build, and save the images and an example that illustrates how to start these services with docker-compose. \
+This repo hosts docker images for APISIX, APISIX dashboard, Prometheus and Grafana (which emit metrics of APISIX). It also includes useful commands to use, build, and save the images and an example that illustrates how to start these services with docker-compose.
 
 **Note**: Docker images are not official ASF releases but provided for convenience. Recommended usage is always to build the source.**
 
@@ -82,7 +82,7 @@ make build-dashboard-centos
 
 ## Run Services With Docker-compose
 
-The following example illustrates how to run APISIX and APISIX dashboard with docker-compose. If you want to manually deploy services, see [this guide](https://github.com/apache/apisix-docker/blob/master/docs/en/latest/manual.md)
+The following example illustrates how to run APISIX and APISIX dashboard with docker-compose. If you want to manually deploy services, please refer to [this guide](https://github.com/apache/apisix-docker/blob/master/docs/en/latest/manual.md)
 
 `/example` contains an example docker-compose file and config files that show how to start apisix and apisix dashboard using docker compose.
 1. Start apisix and apisix dashboard

--- a/README.md
+++ b/README.md
@@ -141,38 +141,57 @@ docker pull apache/apisix:dev
 ```
 ## All commands
 Commands supported by apisix-docker
-* centos:\
+* Centos:\
+  Supported arch: amd64, arm32v6, i386 \
   ```make build-on-centos``` \
-  Build apache/apisix:xx-centos image. You can use this command to build apisix on centos.\
-  Supported arch: amd64, arm32v6, i386
+  Build apache/apisix:xx-centos image. This command can be used to build apisix on centos.\
   
   ```make push-on-centos```\
   Build and push apache/apisix:xx-centos image.\
-  Supported arch: amd64, arm32v6, i386
   
   ```make save-centos-tar```\
   Save apache/apisix:xx-centos image to a tar archive located at ```./package``` . \
-  Supported arch: amd64, arm32v6, i386
   
-* dev:
-```
-  make build-on-alpine-dev
-```
-* alpine:
-```
-  make build-on-alpine
-  make build-on-alpine-cn
-  make build-on-alpine-local
-  make push-on-alpine
-  make save-alpine-tar
-```
+* Alpine:\
+  Supported arch: amd64, arm64\
+  ```make build-on-alpine```\
+  Build apache/apisix:xx-alpine image.\
+  
+  ```make build-on-alpine-dev```\
+  Build apache/apisix:xx-alpine-dev image.\
+  
+  ```make build-on-alpine-cn```\
+  Build apache/apisix:xx-alpine image (for Chinese)\
+  
+  ```make build-on-alpine-local```\
+  Build apache/apisix:xx-alpine-local image. This command can be used to build image on local code.\
+  
+  ```make push-multiarch-on-alpine```\
+  Push apache/apisix:xx-alpine image.\
+  
+  ```make save-alpine-tar```\
+  Save apache/apisix:xx-alpine image to a tar archive located at ```./package``` . \
+
 * All-in-one:
-```
-  make build-all-in-one
-  make build-dashboard-all-in-one
-  make build-dashboard-centos
-  make build-dashboard-alpine
-  make push-multiarch-dashboard
-  make save-dashboard-centos-tar
-  make save-dashboard-alpine-tar
+  Supported arch: amd64, arm64\
+  ```make build-all-in-one```\
+  Build APISIX.
+  
+  ```make build-dashboard-all-in-one```\
+  Build APISIX-dashboard.
+  
+  ```make build-dashboard-centos```\
+  Build apache/dashboard:tag image on centos. This can be used to build APISIX dashboard on centos.
+  
+  ```make build-dashboard-alpine```\
+  Build apache/dashboard:tag image on alpine. This can be used to build APISIX dashboard on alpine.
+  
+  ```make push-multiarch-dashboard```\
+  Build and push multiarch apache/dashboard:tag image. This can be used to build and push APISIX dashboard on centos and on alpine.
+  
+  ```make save-dashboard-centos-tar```\
+   Save apache/apisix-dashboard:tag image to a tar archive located at ```./package``` . \
+  
+  ```make save-dashboard-alpine-tar```\
+  Save apache/apisix-dashboard:tag image to a tar archive located at ```./package``` . \
 ```

--- a/README.md
+++ b/README.md
@@ -1,69 +1,29 @@
-## What's in this image?
-  The APISIX image has everything you need to get APISIX up and running. It installs all the dependencies, then starts APISIX and the etcd server (which persists the data for APISIX).
+## What is APISIX?
+
+Apache APISIX is a dynamic, real-time, high-performance API gateway. APISIX provides rich traffic management features such as load balancing, dynamic upstream, canary release, circuit breaking, authentication, observability, and more.
+
+See https://apisix.apache.org/ for more info.
 
 ## Image variants
-  The APISIX images come in many flavors, each designed for a specific use case.
 
-  `apisix:<version>`
+The APISIX image comes in many flavors, each designed for a specific use case.
 
-  This is the defacto image. If you are unsure about what your needs are, you probably want to use this one. It is designed to be used both as a throw away container (mount your source code and start the container to start your app), as well as the base to build other images off of.
+`apisix:<version>`
 
-  `apisix:<version>-alpine`
+This is the defacto image. If you are unsure about what your needs are, you probably want to use this one. It is designed to be used both as a throw away container (mount your source code and start the container to start your app), as well as the base to build other images off of.
 
-  This image is based on the popular Alpine Linux project, available in the alpine official image. Alpine Linux is much smaller than most distribution base images (~5MB), and thus leads to much slimmer images in general.
+`apisix:<version>-alpine`
 
-  This variant is useful when final image size being as small as possible is your primary concern. The main caveat to note is that it does use musl libc instead of glibc and friends, so software will often run into issues depending on the depth of their libc requirements/assumptions. See this Hacker News comment thread for more discussion of the issues that might arise and some pro/con comparisons of using Alpine-based images.
+This image is based on the popular Alpine Linux project, available in the alpine official image. Alpine Linux is much smaller than most distribution base images (~5MB), and thus leads to much slimmer images in general.
 
-  To minimize image size, it's uncommon for additional related tools (such as git or bash) to be included in Alpine-based images. Using this image as a base, add the things you need in your own Dockerfile (see the alpine image description for examples of how to install packages if you are unfamiliar).
+This variant is useful when final image size being as small as possible is your primary concern. The main caveat to note is that it does use musl libc instead of glibc and friends, so software will often run into issues depending on the depth of their libc requirements/assumptions. See this Hacker News comment thread for more discussion of the issues that might arise and some pro/con comparisons of using Alpine-based images.
 
-  `apisix:<version>-centos`
+To minimize image size, it's uncommon for additional related tools (such as git or bash) to be included in Alpine-based images. Using this image as a base, add the things you need in your own Dockerfile (see the alpine image description for examples of how to install packages if you are unfamiliar).
 
+`apisix:<version>-centos`
 
-## How To Use this Image?
-[The apisix-docker repo] contains a list of makefile commands which makes it easy to build images. 
+## How to run APISIX?
 
-To build the APISIX image, specify the version of APISIX by setting `APISIX_VERSION`. It is recommended to use the latest release version, which can be found at https://github.com/apache/apisix/releases.
-
-```sh
-# The latest release version can be find at `https://github.com/apache/apisix/releases`, for example: 2.9
-export APISIX_VERSION=2.9
-
-# build alpine based image
-make build-on-alpine
-
-# build centos based image
-make build-on-centos
-```
-
-Alternatively, you can build APISIX from your local code.
-```sh
-# To copy the local apisix into image, we need to include it in build context
-cp -r <APISIX-PATH> ./apisix
-
-export APISIX_PATH=./apisix
-make build-on-alpine-local
-
-# Might need root privilege if encounter "error checking context: 'can't start'"
-```
-
-**Note:** For Chinese, the following command is always recommended. The additional build argument `ENABLE_PROXY=true` will enable proxy to definitely accelerate the progress.
-
-To build the APISIX dashboard image, specify the version of APISIX dashboard by setting `APISIX_DASHBOARD_VERSION`. It is recommended to use the latest release version, which can be found at https://github.com/apache/apisix-dashboard/releases.
-
-```sh
-# The latest release version can be found at `https://github.com/apache/apisix-dashboard/releases`, for example: 2.10
-export APISIX_DASHBOARD_VERSION=2.10
-
-# build alpine based image
-make build-dashboard-alpine
-
-# build centos based image
-make build-dashboard-centos
-```
-
-Note that we are not able to run APISIX yet because etcd, which APISIX depends on to persist data, has not been configured and started. The following section shows two ways to run APISIX.
-
-## How to run APISIX
 APISIX can be run using docker compose or using the `all-in-one` image. It is recommended to use docker compose to run APISIX, as `all-in-one` deploys all dependencies in a single container and should be used for quick testing.
 If you want to manually deploy services, please refer to [this guide](https://github.com/apache/apisix-docker/blob/master/docs/en/latest/manual.md).
 
@@ -110,7 +70,7 @@ If you want to use a config file from a different path, you need to modify the l
 
 ### Run APISIX with all-in-one command 
 
-A quick way to get APISIX running on alpine is to use the `all-in-one` docker image, which deploys all dependencies in one Docker container. 
+A quick way to get APISIX running on alpine is to use the `all-in-one` docker image, which deploys all dependencies in one Docker container. You can find the dockerfile [here](https://github.com/apache/apisix-docker/blob/master/all-in-one/apisix/Dockerfile).
 
 - All in one Docker container for Apache APISIX
 
@@ -151,6 +111,55 @@ docker run -d \
 -v `pwd`/all-in-one/apisix-dashboard/conf.yaml:/usr/local/apisix-dashboard/conf/conf.yaml \
 apache/apisix-dashboard:whole
 ```
+
+## How To Build this Image?
+
+[The apisix-docker repo](https://github.com/apache/apisix-docker) contains a list of makefile commands which makes it easy to build images. 
+
+There are two build arguments that can be set:
+`APISIX_VERSION`: To build the APISIX image, specify the version of APISIX by setting `APISIX_VERSION`. The latest release version can be found at https://github.com/apache/apisix/releases. 
+`ENABLE_PROXY`: Set `ENABLE_PROXY=true` to enable the proxy to accelerate the build process.
+
+To use these commands, clone [the repo](https://github.com/apache/apisix-docker) and cd into its root folder.
+
+```sh
+# The latest release version can be find at `https://github.com/apache/apisix/releases`, for example: 2.9
+export APISIX_VERSION=2.9
+
+# build alpine based image
+make build-on-alpine
+
+# build centos based image
+make build-on-centos
+```
+
+Alternatively, you can build APISIX from your local code.
+```sh
+# To copy the local apisix into image, we need to include it in build context
+cp -r <APISIX-PATH> ./apisix
+
+export APISIX_PATH=./apisix
+make build-on-alpine-local
+
+# Might need root privilege if encounter "error checking context: 'can't start'"
+```
+
+**Note:** For Chinese, the following command is always recommended. The additional build argument `ENABLE_PROXY=true` will enable proxy to definitely accelerate the progress.
+
+To build the APISIX dashboard image, specify the version of APISIX dashboard by setting `APISIX_DASHBOARD_VERSION`. The latest release version can be found at https://github.com/apache/apisix-dashboard/releases.
+
+```sh
+# The latest release version can be found at `https://github.com/apache/apisix-dashboard/releases`, for example: 2.10
+export APISIX_DASHBOARD_VERSION=2.10
+
+# build alpine based image
+make build-dashboard-alpine
+
+# build centos based image
+make build-dashboard-centos
+```
+
+Note that we are not able to run APISIX yet because etcd, which APISIX depends on to persist data, has not been configured and started. The following section shows two ways to run APISIX.
 
 ### Note
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## Summary
-This repo contains docker images for APISIX, APISIX dashboard, Prometheus and Grafana (which emit metrics of APISIX). It also includes useful commands to use, build, and save the images and an example that illustrates how to start these services with docker-compose.
+This repo contains docker images for APISIX and APISIX dashboard. It also includes useful commands to use, build, and save the images and an example that illustrates how to start these services with docker-compose.
 
 **Note**: Docker images are not official ASF releases but provided for convenience. Recommended usage is always to build the source.
 
@@ -12,8 +12,6 @@ The repo contains the following images:
 - `/centos/Dockerfile`builds APISIX on centos.
 
 - `/dashboard` contains two docker files - `Dockerfile.alpine` and `Dockerfile.centos`, which build APISIX dashboard on alpine and centos respectively.
-
-- `/all-in-one` enables you to quickly start apisix on alpine by following [these steps](https://github.com/apache/apisix-docker#quick-test-with-all-dependencies-in-one-docker-container).
 
 You can build these images as follows:
 
@@ -115,7 +113,7 @@ The example docker compose file defines several services: `apisix-dashboard, api
 All the services are configured by mounting external configuration files onto the containers: `./dashboard_conf/conf.yaml` defines the configs for `apisix-dashboard`; `./apisix_conf/conf.yaml` defines the configs for apisix. Similarly, configs for etcd, prometheus, and grafana are located in the corresponding conf.yaml files. If you want to use a config file from a different path, you need to modify the local config file path in the `volumes` entry under the corresponding service.
 
 ## Quick test with all dependencies in one Docker container
-A quick way to get APISIX running is to use the provided all-in-one docker images, which deploys all dependencies in one Docker container. 
+A quick way to get APISIX running on alpine is to use the provided all-in-one docker images, which deploys all dependencies in one Docker container. 
 
 * All in one Docker container for Apache APISIX
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 ## Summary
-This repo contains docker images for APISIX and APISIX dashboard. It also includes useful commands to use, build, and save the images and an example that illustrates how to start these services with docker-compose.
-
-**Note**: Docker images are not official ASF releases but provided for convenience. Recommended usage is always to build the source.
+This repo includes:
+1. docker images for APISIX and APISIX dashboard (on alpine and centos). 
+2. examples that show how to get APISIX and APISIX dashboard up and running. 
+3. a list of commands that allow users to easily build, save, and tar the docker images.
 
 ## How To Build Images
+
+**Note**: Docker images are not official ASF releases but provided for convenience. Recommended usage is always to build the source.
 
 The repo contains the following images:
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ This is the default image. If you are unsure about what your needs are, this is 
 
 This image is based on the popular Alpine Linux project. Since Alpine Linux is much smaller than most distribution Linux images (~5MB), you can build smaller images with it.
 
-This variant is useful when final image size being as small as possible is your primary concern. The main caveat to note is that it does use musl libc instead of glibc and friends, so software will often run into issues depending on the depth of their libc requirements/assumptions. See this Hacker News comment thread for more discussion of the issues that might arise and some pro/con comparisons of using Alpine-based images.
+This variant is useful when storage compatibility is your primary concern. The main caveat to note is that it does use `musl libc` instead of `glibc` and friends, so software will often run into issues depending on the depth of their `libc requirements/assumptions`. See this [Hacker News comment thread](https://news.ycombinator.com/item?id=10782897) for more discussion of the issues that might arise and some advantages and disadvantages comparisons of using Alpine-based images.
 
-To minimize image size, it's uncommon for additional related tools (such as git or bash) to be included in Alpine-based images. Using this image as a base, add the things you need in your own Dockerfile (see the alpine image description for examples of how to install packages if you are unfamiliar).
+To minimize the image size, additional tools, such as git and bash, are not included in Alpine-based images. Using this image as a base, add the things you need in your own Dockerfile (see the [alpine image description](https://hub.docker.com/_/alpine/)).
 
 `apisix:<version>-centos`
 
@@ -38,15 +38,19 @@ If you want to manually deploy services, please refer to [this guide](https://gi
 To try out this example:
 
 1. Clone the [repo](https://github.com/apache/apisix-docker) and cd into the root folder.
+    ```
+    git clone 'https://github.com/apache/apisix-docker'
+    cd apisix-docker
+    ```
   
-2. Start APISIX.
+1. Start APISIX.
     ```
     cd example
 
     docker-compose -p docker-apisix up -d
     ```
 
-3. Check if APISIX is running properly by running this command and checking the response.
+2. Check if APISIX is running properly by running this command and checking the response.
     ```
     curl "http://127.0.0.1:9080/apisix/admin/services/" -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1'
     ```
@@ -64,7 +68,7 @@ To try out this example:
     ```
 
 The [example docker compose file](https://github.com/apache/apisix-docker/blob/master/example/docker-compose.yml) defines several services: `apisix-dashboard, apisix, etcd, web1, web2, prometheus, and grafana`:
-- `apisix-dashboard, apisix, etcd` are the essential services required for starting apisix-dashboard, apisix, etcd.
+- `apisix-dashboard, apisix, etcd` are the essential services required for starting apisix-dashboard, apisix, and etcd.
 - `web1, web2` are sample backend services used for testing purposes. They use nginx-alpine image.  
 - `prometheus, grafana` are services used for exposing metrics of the running services.
 
@@ -78,7 +82,7 @@ A quick way to get APISIX running on alpine is to use the `all-in-one` docker im
 
 To try out this example:
 
-1. Clone the [apisix-docker repo](https://github.com/apache/apisix-docker/blob/master) and cd into the root folder.
+1. Make sure that you are in the root folder of apisix-docker.
 
 2. `make build-all-in-one` to build the `all-in-one` image.
 
@@ -106,6 +110,7 @@ To try out this example:
         "dir":true
       }
     }
+    ```
 
 The configuration file for the service is located at [/all-in-one/apisix/config.yaml](https://github.com/apache/apisix-docker/blob/master/all-in-one/apisix/config.yaml). It is mounted onto the container at runtime.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-## What is APISIX?
+## What is APISIX
 
 Apache APISIX is a dynamic, real-time, high-performance API gateway. APISIX provides rich traffic management features such as load balancing, dynamic upstream, canary release, circuit breaking, authentication, observability, and more.
 
-See https://apisix.apache.org/ for more info.
+See [apisix](https://apisix.apache.org/) for more info.
 
 ## Image variants
 
@@ -24,7 +24,7 @@ To minimize image size, it's uncommon for additional related tools (such as git 
 
 [placeholder: description for centos]
 
-## How to run APISIX?
+## How to run APISIX
 
 APISIX can be run using docker compose or using the `all-in-one` image. It is recommended to use docker compose to run APISIX, as `all-in-one` deploys all dependencies in a single container and should be used for quick testing.
 If you want to manually deploy services, please refer to [this guide](https://github.com/apache/apisix-docker/blob/master/docs/en/latest/manual.md).
@@ -70,7 +70,7 @@ All the services are configured by mounting external configuration files onto th
 
 If you want to use a config file located at a different path, you need to modify the local config file path in the `volumes` entry under the corresponding service.
 
-### Run APISIX with all-in-one command 
+### Run APISIX with all-in-one command
 
 A quick way to get APISIX running on alpine is to use the `all-in-one` docker image, which deploys all dependencies in one Docker container. You can find the dockerfile [here](https://github.com/apache/apisix-docker/blob/master/all-in-one/apisix/Dockerfile). The image utilizes [multi-stage build](https://docs.docker.com/develop/develop-images/multistage-build/), building APISIX layer and etcd layer first, then copying the nesessary artifacts to the alpine layer.
 
@@ -107,12 +107,12 @@ apache/apisix:whole
 
 The configuration file for the service is located at [/all-in-one/apisix/config.yaml](https://github.com/apache/apisix-docker/blob/master/all-in-one/apisix/config.yaml). It is mounted onto the container at runtime.
 
-## How To Build this Image?
+## How To Build this Image
 
 [The apisix-docker repo](https://github.com/apache/apisix-docker) contains a list of makefile commands which makes it easy to build images. To use these commands, clone [the repo](https://github.com/apache/apisix-docker) and cd into its root folder.
 
 There are two build arguments that can be set:
-`APISIX_VERSION`: To build the APISIX image, specify the version of APISIX by setting `APISIX_VERSION`. The latest release version can be found at https://github.com/apache/apisix/releases. 
+`APISIX_VERSION`: To build the APISIX image, specify the version of APISIX by setting `APISIX_VERSION`. The latest. release version can be found here [apisix/releases](https://github.com/apache/apisix/releases).
 `ENABLE_PROXY`: Set `ENABLE_PROXY=true` to enable the proxy to accelerate the build process.
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Apache APISIX is a dynamic, real-time, high-performance API gateway. APISIX provides rich traffic management features such as load balancing, dynamic upstream, canary release, circuit breaking, authentication, observability, and more.
 
-See [apisix](https://apisix.apache.org/) for more info.
+See [the APISIX website](https://apisix.apache.org/) for more info.
 
 ## Image variants
 
@@ -35,7 +35,7 @@ If you want to manually deploy services, please refer to [this guide](https://gi
 
 To try out this example:
 
-1. Clone the [repo](https://github.com/apache/apisix-docker/blob/master) and cd into the root folder.
+1. Clone the [repo](https://github.com/apache/apisix-docker) and cd into the root folder.
   
 2. Start APISIX.
     ```
@@ -109,7 +109,7 @@ The configuration file for the service is located at [/all-in-one/apisix/config.
 
 ## How To Build this Image
 
-[The apisix-docker repo](https://github.com/apache/apisix-docker) contains a list of makefile commands which makes it easy to build images. To use these commands, clone [the repo](https://github.com/apache/apisix-docker) and cd into its root folder.
+The apisix-docker repo contains a list of makefile commands which makes it easy to build images. To use these commands, clone [the repo](https://github.com/apache/apisix-docker) and cd into its root folder.
 
 There are two build arguments that can be set:
 `APISIX_VERSION`: To build the APISIX image, specify the version of APISIX by setting `APISIX_VERSION`. The latest. release version can be found here [apisix/releases](https://github.com/apache/apisix/releases).

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This is the default image. If you are unsure about what your needs are, this is 
 
 `apisix:<version>-alpine`
 
-This image is based on the popular Alpine Linux project, available in the alpine official image. Alpine Linux is much smaller than most distribution base images (~5MB), and thus leads to much slimmer images in general.
+This image is based on the popular Alpine Linux project. Since Alpine Linux is much smaller than most distribution Linux images (~5MB), you can build smaller images with it.
 
 This variant is useful when final image size being as small as possible is your primary concern. The main caveat to note is that it does use musl libc instead of glibc and friends, so software will often run into issues depending on the depth of their libc requirements/assumptions. See this Hacker News comment thread for more discussion of the issues that might arise and some pro/con comparisons of using Alpine-based images.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ To minimize image size, it's uncommon for additional related tools (such as git 
 
 `apisix:<version>-centos`
 
-[placeholder: description for centos]
+This image is based on the CentOS Linux project, available in the centos official image. CentOS is derived from the sources of Red Hat Enterprise Linux (RHEL). It is considered to be a more stable distribution compared to Ubuntu, mainly because package updates are less frequent.
+
+The variant is useful when your primary concern is stability and want to minimize the number of image updates. The applications running on CentOS don't need to be updated as often owing to the lesser frequency of its updates, and the cost is also very less than compared with other Linux essentials.
 
 ## How to run APISIX
 
@@ -82,12 +84,12 @@ To try out this example:
 
 3. Launch the APISIX container:
 
-```sh
-docker run -d \
--p 9080:9080 -p 9091:9091 -p 2379:2379 \
--v `pwd`/all-in-one/apisix/config.yaml:/usr/local/apisix/conf/config.yaml \
-apache/apisix:whole
-```
+    ```sh
+    docker run -d \
+    -p 9080:9080 -p 9091:9091 -p 2379:2379 \
+    -v `pwd`/all-in-one/apisix/config.yaml:/usr/local/apisix/conf/config.yaml \
+    apache/apisix:whole
+    ```
 
 4. Check if APISIX is running properly by running this command and checking the response.
     ```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The APISIX image comes in many flavors, each designed for a specific use case.
 
 `apisix:<version>`
 
-This is the defacto image. If you are unsure about what your needs are, you probably want to use this one. It is designed to be used both as a throw away container (mount your source code and start the container to start your app), as well as the base to build other images off of.
+This is the default image. If you are unsure about what your needs are, this is your go-to option.you can use it as a throw away container (mount your source code and start the container to start your applications), as well as the base to build other images of.
 
 `apisix:<version>-alpine`
 

--- a/README.md
+++ b/README.md
@@ -139,3 +139,40 @@ At `0:00 UTC` every day, the APISIX `master` code will be automatically built an
 ```bash
 docker pull apache/apisix:dev
 ```
+## All commands
+Commands supported by apisix-docker
+* centos:\
+  ```make build-on-centos``` \
+  Build apache/apisix:xx-centos image. You can use this command to build apisix on centos.\
+  Supported arch: amd64, arm32v6, i386
+  
+  ```make push-on-centos```\
+  Build and push apache/apisix:xx-centos image.\
+  Supported arch: amd64, arm32v6, i386
+  
+  ```make save-centos-tar```\
+  Save apache/apisix:xx-centos image to a tar archive located at ```./package``` . \
+  Supported arch: amd64, arm32v6, i386
+  
+* dev:
+```
+  make build-on-alpine-dev
+```
+* alpine:
+```
+  make build-on-alpine
+  make build-on-alpine-cn
+  make build-on-alpine-local
+  make push-on-alpine
+  make save-alpine-tar
+```
+* All-in-one:
+```
+  make build-all-in-one
+  make build-dashboard-all-in-one
+  make build-dashboard-centos
+  make build-dashboard-alpine
+  make push-multiarch-dashboard
+  make save-dashboard-centos-tar
+  make save-dashboard-alpine-tar
+```

--- a/README.md
+++ b/README.md
@@ -144,13 +144,19 @@ Commands supported by apisix-docker
 * Centos:\
   Supported arch: amd64, arm32v6, i386 \
   ```make build-on-centos``` \
-  Build apache/apisix:xx-centos image. This command can be used to build apisix on centos.\
+  Build apache/apisix:xx-centos image. This command can be used to build apisix on centos.
   
   ```make push-on-centos```\
-  Build and push apache/apisix:xx-centos image.\
+  Build and push apache/apisix:xx-centos image.
   
   ```make save-centos-tar```\
-  Save apache/apisix:xx-centos image to a tar archive located at ```./package``` . \
+  Save apache/apisix:xx-centos image to a tar archive located at ```./package``` . 
+  
+  ```make build-dashboard-centos```\
+  Build apache/dashboard:tag image on centos. This can be used to build APISIX dashboard on centos.
+  
+  ```make save-dashboard-centos-tar```\
+   Save apache/apisix-dashboard:tag image to a tar archive located at ```./package``` . 
   
 * Alpine:\
   Supported arch: amd64, arm64\
@@ -158,19 +164,25 @@ Commands supported by apisix-docker
   Build apache/apisix:xx-alpine image.\
   
   ```make build-on-alpine-dev```\
-  Build apache/apisix:xx-alpine-dev image.\
+  Build apache/apisix:xx-alpine-dev image.
   
   ```make build-on-alpine-cn```\
-  Build apache/apisix:xx-alpine image (for Chinese)\
+  Build apache/apisix:xx-alpine image (for Chinese)
   
   ```make build-on-alpine-local```\
-  Build apache/apisix:xx-alpine-local image. This command can be used to build image on local code.\
+  Build apache/apisix:xx-alpine-local image. This command can be used to build image on local code.
   
   ```make push-multiarch-on-alpine```\
-  Push apache/apisix:xx-alpine image.\
+  Push apache/apisix:xx-alpine image.
   
   ```make save-alpine-tar```\
-  Save apache/apisix:xx-alpine image to a tar archive located at ```./package``` . \
+  Save apache/apisix:xx-alpine image to a tar archive located at ```./package``` . 
+  
+  ```make build-dashboard-alpine```\
+  Build apache/dashboard:tag image on alpine. This can be used to build APISIX dashboard on alpine.
+  
+  ```make save-dashboard-alpine-tar```\
+  Save apache/apisix-dashboard:tag image to a tar archive located at ```./package``` . 
 
 * All-in-one:
   Supported arch: amd64, arm64\
@@ -180,18 +192,5 @@ Commands supported by apisix-docker
   ```make build-dashboard-all-in-one```\
   Build APISIX-dashboard.
   
-  ```make build-dashboard-centos```\
-  Build apache/dashboard:tag image on centos. This can be used to build APISIX dashboard on centos.
-  
-  ```make build-dashboard-alpine```\
-  Build apache/dashboard:tag image on alpine. This can be used to build APISIX dashboard on alpine.
-  
   ```make push-multiarch-dashboard```\
   Build and push multiarch apache/dashboard:tag image. This can be used to build and push APISIX dashboard on centos and on alpine.
-  
-  ```make save-dashboard-centos-tar```\
-   Save apache/apisix-dashboard:tag image to a tar archive located at ```./package``` . \
-  
-  ```make save-dashboard-alpine-tar```\
-  Save apache/apisix-dashboard:tag image to a tar archive located at ```./package``` . \
-```

--- a/README.md
+++ b/README.md
@@ -4,28 +4,6 @@ Apache APISIX is a dynamic, real-time, high-performance API gateway. APISIX prov
 
 See [the APISIX website](https://apisix.apache.org/) for more info.
 
-## Image variants
-
-The APISIX image comes in many flavors, each designed for a specific use case.
-
-`apisix:<version>`
-
-This is the default image. If you are unsure about what your needs are, this is your go-to option.you can use it as a throw away container (mount your source code and start the container to start your applications), as well as the base to build other images of.
-
-`apisix:<version>-alpine`
-
-This image is based on the popular Alpine Linux project. Since Alpine Linux is much smaller than most distribution Linux images (~5MB), you can build smaller images with it.
-
-This variant is useful when storage compatibility is your primary concern. The main caveat to note is that it does use `musl libc` instead of `glibc` and friends, so software will often run into issues depending on the depth of their `libc requirements/assumptions`. See this [Hacker News comment thread](https://news.ycombinator.com/item?id=10782897) for more discussion of the issues that might arise and some advantages and disadvantages comparisons of using Alpine-based images.
-
-To minimize the image size, additional tools, such as git and bash, are not included in Alpine-based images. Using this image as a base, add the things you need in your own Dockerfile (see the [alpine image description](https://hub.docker.com/_/alpine/)).
-
-`apisix:<version>-centos`
-
-This image is based on the CentOS Linux project, available in the centos official image. CentOS is derived from the sources of Red Hat Enterprise Linux (RHEL). It is considered to be a more stable distribution compared to Ubuntu, mainly because package updates are less frequent.
-
-The variant is useful when your primary concern is stability and want to minimize the number of image updates. The applications running on CentOS don't need to be updated as often owing to the lesser frequency of its updates, and the cost is also very less than compared with other Linux essentials.
-
 ## How to run APISIX
 
 APISIX can be run using docker compose or using the `all-in-one` image. It is recommended to use docker compose to run APISIX, as `all-in-one` deploys all dependencies in a single container and should be used for quick testing.
@@ -168,3 +146,25 @@ At `0:00 UTC` every day, the APISIX `master` code will be automatically built an
 ```bash
 docker pull apache/apisix:dev
 ```
+
+## Image variants
+
+The APISIX image comes in many flavors, each designed for a specific use case.
+
+`apisix:<version>`
+
+This is the default image. If you are unsure about what your needs are, this is your go-to option.you can use it as a throw away container (mount your source code and start the container to start your applications), as well as the base to build other images of.
+
+`apisix:<version>-alpine`
+
+This image is based on the popular Alpine Linux project. Since Alpine Linux is much smaller than most distribution Linux images (~5MB), you can build smaller images with it.
+
+This variant is useful when storage compatibility is your primary concern. The main caveat to note is that it does use `musl libc` instead of `glibc` and friends, so software will often run into issues depending on the depth of their `libc requirements/assumptions`. See this [Hacker News comment thread](https://news.ycombinator.com/item?id=10782897) for more discussion of the issues that might arise and some advantages and disadvantages comparisons of using Alpine-based images.
+
+To minimize the image size, additional tools, such as git and bash, are not included in Alpine-based images. Using this image as a base, add the things you need in your own Dockerfile (see the [alpine image description](https://hub.docker.com/_/alpine/)).
+
+`apisix:<version>-centos`
+
+This image is based on the CentOS Linux project, available in the centos official image. CentOS is derived from the sources of Red Hat Enterprise Linux (RHEL). It is considered to be a more stable distribution compared to Ubuntu, mainly because package updates are less frequent.
+
+The variant is useful when your primary concern is stability and want to minimize the number of image updates. The applications running on CentOS don't need to be updated as often owing to the lesser frequency of its updates, and the cost is also very less than compared with other Linux essentials.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## Summary
-This repo hosts docker images for APISIX, APISIX dashboard, Prometheus and Grafana (which emit metrics of APISIX). It also includes useful commands to use, build, and save the images and an example that illustrates how to start these services with docker-compose.
+This repo contains docker images for APISIX, APISIX dashboard, Prometheus and Grafana (which emit metrics of APISIX). It also includes useful commands to use, build, and save the images and an example that illustrates how to start these services with docker-compose.
 
-**Note**: Docker images are not official ASF releases but provided for convenience. Recommended usage is always to build the source.**
+**Note**: Docker images are not official ASF releases but provided for convenience. Recommended usage is always to build the source.
 
 ## How To Build Images
 
@@ -11,7 +11,7 @@ The repo contains the following images:
 
 - `/centos/Dockerfile`builds APISIX on centos.
 
-- `/dashboard` contains two docker files - `Dockerfile.alpine` and `Dockerfile.centos`, which build apisix dashboard on alpine and centos respectively.
+- `/dashboard` contains two docker files - `Dockerfile.alpine` and `Dockerfile.centos`, which build APISIX dashboard on alpine and centos respectively.
 
 - `/all-in-one` enables you to quickly start apisix on alpine by following [these steps](https://github.com/apache/apisix-docker#quick-test-with-all-dependencies-in-one-docker-container).
 
@@ -20,8 +20,6 @@ You can build these images as follows:
 **Note**: The master branch is for the version of Apache APISIX 2.x. If you need a previous version, please build from the [v1.x](https://github.com/apache/apisix-docker/releases/tag/v1.x) tag.
 
 ### Build an image from source
-
-You can build images as follows:
 
 1. Build from release version:
 ```sh
@@ -80,9 +78,9 @@ make build-dashboard-alpine
 make build-dashboard-centos
 ```
 
-## Run Services With Docker-compose
+## Run With Docker-compose
 
-The following example illustrates how to run APISIX and APISIX dashboard with docker-compose. If you want to manually deploy services, please refer to [this guide](https://github.com/apache/apisix-docker/blob/master/docs/en/latest/manual.md)
+The following example illustrates how to run APISIX and APISIX dashboard with docker-compose. If you want to manually deploy services, please refer to [this guide](https://github.com/apache/apisix-docker/blob/master/docs/en/latest/manual.md).
 
 `/example` contains an example docker-compose file and config files that show how to start apisix and apisix dashboard using docker compose.
 1. Start apisix and apisix dashboard
@@ -117,7 +115,7 @@ The example docker compose file defines several services: `apisix-dashboard, api
 All the services are configured by mounting external configuration files onto the containers: `./dashboard_conf/conf.yaml` defines the configs for `apisix-dashboard`; `./apisix_conf/conf.yaml` defines the configs for apisix. Similarly, configs for etcd, prometheus, and grafana are located in the corresponding conf.yaml files. If you want to use a config file from a different path, you need to modify the local config file path in the `volumes` entry under the corresponding service.
 
 ## Quick test with all dependencies in one Docker container
-Another way to deploy services is to use the provided all-in-one docker images, which deploys all dependencies in one Docker container. 
+A quick way to get APISIX running is to use the provided all-in-one docker images, which deploys all dependencies in one Docker container. 
 
 * All in one Docker container for Apache APISIX
 
@@ -167,7 +165,7 @@ As an example, these are the commands for apisix-centos images:
 
 -  ```make save-centos-tar```:  Save apache/apisix:xx-centos image to a tar archive located at ```./package``` . 
 
-Similar commands exist for apisix-alpine images and apisix dashboard. See [the makefile](https://github.com/apache/apisix-docker/blob/master/Makefile) for a full list of commands. 
+Similar commands exist for apisix-alpine images and apisix dashboard. See [the makefile](/Makefile) for a full list of commands. 
 
 ### Note
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,27 @@
-**Docker images are not official ASF releases but provided for convenience. Recommended usage is always to build the source.**
+## Summary
+This repo hosts docker images for APISIX, APISIX dashboard, Prometheus and Grafana (which emit metrics of APISIX). It also includes useful commands to use, build, and save the images and an example that illustrates how to start these services with docker-compose. \
 
-## How To Build Image
+**Note**: Docker images are not official ASF releases but provided for convenience. Recommended usage is always to build the source.**
 
-**The master branch is for the version of Apache APISIX 2.x. If you need a previous version, please build from the [v1.x](https://github.com/apache/apisix-docker/releases/tag/v1.x) tag.**
+## How To Build Images
+
+The repo contains the following images:
+
+- `/alpine/Dockerfile` builds APISIX on alpine.
+
+- `/centos/Dockerfile`builds APISIX on centos.
+
+- `/dashboard` contains two docker files - `Dockerfile.alpine` and `Dockerfile.centos`, which build apisix dashboard on alpine and centos respectively.
+
+- `/all-in-one` enables you to quickly start apisix on alpine by following [these steps](https://github.com/apache/apisix-docker#quick-test-with-all-dependencies-in-one-docker-container).
+
+You can build these images as follows:
+
+**Note**: The master branch is for the version of Apache APISIX 2.x. If you need a previous version, please build from the [v1.x](https://github.com/apache/apisix-docker/releases/tag/v1.x) tag.
 
 ### Build an image from source
+
+You can build images as follows:
 
 1. Build from release version:
 ```sh
@@ -63,22 +80,44 @@ make build-dashboard-alpine
 make build-dashboard-centos
 ```
 
-### Manual deploy apisix via docker
+## Run Services With Docker-compose
 
-[Manual deploy](https://github.com/apache/apisix-docker/blob/master/docs/en/latest/manual.md)
+The following example illustrates how to run APISIX and APISIX dashboard with docker-compose. If you want to manually deploy services, see [this guide](https://github.com/apache/apisix-docker/blob/master/docs/en/latest/manual.md)
 
-### QuickStart via docker-compose
+`/example` contains an example docker-compose file and config files that show how to start apisix and apisix dashboard using docker compose.
+1. Start apisix and apisix dashboard
+    ```
+    cd example
+    docker-compose -p docker-apisix up -d
+    ```
+ 
+2. Check if APISIX is running properly by running this command and checking the response.
+    ```
+    curl "http://127.0.0.1:9080/apisix/admin/services/" -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1'
+    ```
+     The response indicates that apisix is running successfully:
+    ```
+    {
+      "count":0,
+      "action":"get",
+      "node":{
+        "key":"/apisix/services",
+        "nodes":[],
+        "dir":true
+      }
+    }
+    ```
+ 
+The example docker compose file defines several services: `apisix-dashboard, apisix, etcd, web1, web2, prometheus, and grafana`:
+`apisix-dashboard, apisix, etcd` are the essential services required for starting apisix-dashboard, apisix, etcd.
+`web1, web2` are sample backend services used for testing purposes.
+`prometheus, grafana` are services used for exposing metrics of the running services.
+ It also creates a bridge network `apisix` which connects all services and a `etcd_data` volume used by the `etcd` service. 
 
-**start all modules with docker-compose**
+All the services are configured by mounting external configuration files onto the containers: `./dashboard_conf/conf.yaml` defines the configs for `apisix-dashboard`; `./apisix_conf/conf.yaml` defines the configs for apisix. Similarly, configs for etcd, prometheus, and grafana are located in the corresponding conf.yaml files. If you want to use a config file from a different path, you need to modify the local config file path in the `volumes` entry under the corresponding service.
 
-```sh
-cd example
-docker-compose -p docker-apisix up -d
-```
-
-You can refer to [the docker-compose example](https://github.com/apache/apisix-docker/blob/master/docs/en/latest/example.md) for more try.
-
-### Quick test with all dependencies in one Docker container
+## Quick test with all dependencies in one Docker container
+Another way to deploy services is to use the provided all-in-one docker images, which deploys all dependencies in one Docker container. 
 
 * All in one Docker container for Apache APISIX
 
@@ -117,6 +156,18 @@ docker run -d \
 -v `pwd`/all-in-one/apisix-dashboard/conf.yaml:/usr/local/apisix-dashboard/conf/conf.yaml \
 apache/apisix-dashboard:whole
 ```
+## Useful commands
+
+Below are some useful commands which build, push, and tar your updated images.
+As an example, these are the commands for apisix-centos images:
+
+-   ```make build-on-centos``` : Build apache/apisix:xx-centos image. 
+
+-   ```make push-on-centos```: Build and push apache/apisix:xx-centos image.
+
+-  ```make save-centos-tar```:  Save apache/apisix:xx-centos image to a tar archive located at ```./package``` . 
+
+Similar commands exist for apisix-alpine images and apisix dashboard. See [the makefile](https://github.com/apache/apisix-docker/blob/master/Makefile) for a full list of commands. 
 
 ### Note
 
@@ -139,72 +190,3 @@ At `0:00 UTC` every day, the APISIX `master` code will be automatically built an
 ```bash
 docker pull apache/apisix:dev
 ```
-## All commands
-
-### APISIX
-
-* **All-in-one**
-  
-  ```make build-all-in-one```\
-  Build APISIX
-
-* **Centos**
-  
-  ```make build-on-centos``` \
-  Build apache/apisix:xx-centos image. This can be used to build APISIX on centos.
-  
-  ```make push-on-centos```\
-  Build and push apache/apisix:xx-centos image.
-  
-  ```make save-centos-tar```\
-  Save apache/apisix:xx-centos image to a tar archive located at ```./package``` . 
-  
-  
-* **Alpine**
-  
-  ```make build-on-alpine```\
-  Build apache/apisix:xx-alpine image.
-  
-  ```make build-on-alpine-dev```\
-  Build apache/apisix:xx-alpine-dev image.
-  
-  ```make build-on-alpine-cn```\
-  Build apache/apisix:xx-alpine image (for Chinese)
-  
-  ```make build-on-alpine-local```\
-  Build apache/apisix:xx-alpine-local image. This can be used to build image on local code.
-  
-  ```make push-multiarch-on-alpine```\
-  Push apache/apisix:xx-alpine image.
-  
-  ```make save-alpine-tar```\
-  Save apache/apisix:xx-alpine image to a tar archive located at ```./package``` . 
-  
-### APISIX Dashboard
-
-* **All-in-one**
-
-  ```make build-dashboard-all-in-one```\
-  Build APISIX-dashboard.
-  
-  ```make push-multiarch-dashboard```\
-  Build and push multiarch apache/dashboard:tag image. This can be used to build and push APISIX dashboard on centos and on alpine.
-
-* **Centos**
-  
-  ```make build-dashboard-centos```\
-  Build apache/dashboard:tag image on centos. This can be used to build APISIX dashboard on centos.
-  
-  ```make save-dashboard-centos-tar```\
-   Save apache/apisix-dashboard:tag image to a tar archive located at ```./package``` .
-  
-* **Alpine**
-  
-  ```make build-dashboard-alpine```\
-  Build apache/dashboard:tag image on alpine. This can be used to build APISIX dashboard on alpine.
-  
-  ```make save-dashboard-alpine-tar```\
-  Save apache/apisix-dashboard:tag image to a tar archive located at ```./package``` . 
-
-
-

--- a/README.md
+++ b/README.md
@@ -1,31 +1,31 @@
-## Summary
+## What's in this image?
+  The APISIX image has everything you need to get APISIX up and running. It installs all the dependencies, then starts APISIX and the etcd server (which persists the data for APISIX).
 
-This repo includes:
-1. docker images for APISIX and APISIX dashboard (on alpine and centos).
-2. examples that show how to get APISIX and APISIX dashboard up and running.
-3. a list of commands that allow users to easily build, save, and tar the docker images.
+## Image variants
+  The APISIX images come in many flavors, each designed for a specific use case.
 
-**Docker images are not official ASF releases but provided for convenience. Recommended usage is always to build the source.**
+  `apisix:<version>`
 
-## How To Build Images
+  This is the defacto image. If you are unsure about what your needs are, you probably want to use this one. It is designed to be used both as a throw away container (mount your source code and start the container to start your app), as well as the base to build other images off of.
 
-The repo contains the following images:
+  `apisix:<version>-alpine`
 
-- `/alpine/Dockerfile` builds APISIX on alpine.
+  This image is based on the popular Alpine Linux project, available in the alpine official image. Alpine Linux is much smaller than most distribution base images (~5MB), and thus leads to much slimmer images in general.
 
-- `/centos/Dockerfile`builds APISIX on centos.
+  This variant is useful when final image size being as small as possible is your primary concern. The main caveat to note is that it does use musl libc instead of glibc and friends, so software will often run into issues depending on the depth of their libc requirements/assumptions. See this Hacker News comment thread for more discussion of the issues that might arise and some pro/con comparisons of using Alpine-based images.
 
-- `/dashboard` contains two docker files - `Dockerfile.alpine` and `Dockerfile.centos`, which build APISIX dashboard on alpine and centos respectively.
+  To minimize image size, it's uncommon for additional related tools (such as git or bash) to be included in Alpine-based images. Using this image as a base, add the things you need in your own Dockerfile (see the alpine image description for examples of how to install packages if you are unfamiliar).
 
-You can build these images as follows:
+  `apisix:<version>-centos`
 
-### Build an image from source
 
-1. Build from release version:
+## How To Use this Image?
+[The apisix-docker repo] contains a list of makefile commands which makes it easy to build images. 
+
+To build the APISIX image, specify the version of APISIX by setting `APISIX_VERSION`. It is recommended to use the latest release version, which can be found at https://github.com/apache/apisix/releases.
+
 ```sh
-# Assign Apache release version to variable `APISIX_VERSION`, for example: 2.9.
-# The latest release version can be find at `https://github.com/apache/apisix/releases`
-
+# The latest release version can be find at `https://github.com/apache/apisix/releases`, for example: 2.9
 export APISIX_VERSION=2.9
 
 # build alpine based image
@@ -35,23 +35,9 @@ make build-on-alpine
 make build-on-centos
 ```
 
-2. Build from master branch version, which has latest code(ONLY for the developer's convenience):
-
-**The master branch is for the version of Apache APISIX 2.x. If you need a previous version, please build from the [v1.x]       (/releases/tag/v1.x) tag.**
-
+Alternatively, you can build APISIX from your local code.
 ```sh
-export APISIX_VERSION=master
-
-# build alpine based image
-make build-on-alpine
-
-# build centos based image
-make build-on-centos
-```
-
-3. Build from local code:
-```sh
-# To copy apisix into image, we need to include it in build context
+# To copy the local apisix into image, we need to include it in build context
 cp -r <APISIX-PATH> ./apisix
 
 export APISIX_PATH=./apisix
@@ -62,16 +48,10 @@ make build-on-alpine-local
 
 **Note:** For Chinese, the following command is always recommended. The additional build argument `ENABLE_PROXY=true` will enable proxy to definitely accelerate the progress.
 
-```sh
-$ make build-on-alpine-cn
-```
-
-4. Build apisix-dashboard from release version:
+To build the APISIX dashboard image, specify the version of APISIX dashboard by setting `APISIX_DASHBOARD_VERSION`. It is recommended to use the latest release version, which can be found at https://github.com/apache/apisix-dashboard/releases.
 
 ```sh
-# Assign the release version of Apache APISIX Dashboard to variable `APISIX_DASHBOARD_VERSION`, for example: 2.10.
-# The latest release version can be found at `https://github.com/apache/apisix-dashboard/releases`
-
+# The latest release version can be found at `https://github.com/apache/apisix-dashboard/releases`, for example: 2.10
 export APISIX_DASHBOARD_VERSION=2.10
 
 # build alpine based image
@@ -81,18 +61,28 @@ make build-dashboard-alpine
 make build-dashboard-centos
 ```
 
-## Run With Docker-compose
+Note that we are not able to run APISIX yet because etcd, which APISIX depends on to persist data, has not been configured and started. The following section shows two ways to run APISIX.
 
-The following example illustrates how to run APISIX and APISIX dashboard with docker-compose. If you want to manually deploy services, please refer to [this guide](https://github.com/apache/apisix-docker/blob/master/docs/en/latest/manual.md).
+## How to run APISIX
+APISIX can be run using docker compose or using the `all-in-one` image. It is recommended to use docker compose to run APISIX, as `all-in-one` deploys all dependencies in a single container and should be used for quick testing.
+If you want to manually deploy services, please refer to [this guide](https://github.com/apache/apisix-docker/blob/master/docs/en/latest/manual.md).
 
-`/example` contains an example docker-compose file and config files that show how to start apisix and apisix dashboard using docker compose.
-1. Start apisix and apisix dashboard
+### Run APISIX with docker-compose
+
+[The apisix-docker repo](https://github.com/apache/apisix-docker/blob/master/example) contains an example docker-compose file and config files that show how to start APISIX and APISIX dashboard using docker compose.
+
+To try out this example:
+
+1. Clone the [repo]((https://github.com/apache/apisix-docker/blob/master) and cd into the root folder.
+  
+2. Start apisix and apisix dashboard
     ```
     cd example
+
     docker-compose -p docker-apisix up -d
     ```
 
-2. Check if APISIX is running properly by running this command and checking the response.
+3. Check if APISIX is running properly by running this command and checking the response.
     ```
     curl "http://127.0.0.1:9080/apisix/admin/services/" -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1'
     ```
@@ -109,17 +99,18 @@ The following example illustrates how to run APISIX and APISIX dashboard with do
     }
     ```
 
-The example docker compose file defines several services: `apisix-dashboard, apisix, etcd, web1, web2, prometheus, and grafana`:
+The [example docker compose file](https://github.com/apache/apisix-docker/blob/master/example/docker-compose.yml) defines several services: `apisix-dashboard, apisix, etcd, web1, web2, prometheus, and grafana`:
 `apisix-dashboard, apisix, etcd` are the essential services required for starting apisix-dashboard, apisix, etcd.
 `web1, web2` are sample backend services used for testing purposes.
 `prometheus, grafana` are services used for exposing metrics of the running services.
- It also creates a bridge network `apisix` which connects all services and a `etcd_data` volume used by the `etcd` service.
 
-All the services are configured by mounting external configuration files onto the containers: `./dashboard_conf/conf.yaml` defines the configs for `apisix-dashboard`; `./apisix_conf/conf.yaml` defines the configs for apisix. Similarly, configs for etcd, prometheus, and grafana are located in the corresponding conf.yaml files. If you want to use a config file from a different path, you need to modify the local config file path in the `volumes` entry under the corresponding service.
+All the services are configured by mounting external configuration files onto the containers: [./apisix_conf/conf.yaml](https://github.com/apache/apisix-docker/blob/master/example/apisix_conf/conf.yaml) defines the configs for apisix. Similarly, configs for etcd, prometheus, and grafana are located in the corresponding conf.yaml files. 
 
-## Quick test with all dependencies in one Docker container
+If you want to use a config file from a different path, you need to modify the local config file path in the `volumes` entry under the corresponding service.
 
-A quick way to get APISIX running on alpine is to use the provided all-in-one docker images, which deploys all dependencies in one Docker container.
+### Run APISIX with all-in-one command 
+
+A quick way to get APISIX running on alpine is to use the `all-in-one` docker image, which deploys all dependencies in one Docker container. 
 
 - All in one Docker container for Apache APISIX
 
@@ -132,6 +123,8 @@ docker run -d \
 -v `pwd`/all-in-one/apisix/config.yaml:/usr/local/apisix/conf/config.yaml \
 apache/apisix:whole
 ```
+
+The configuration file for the service is located at [/all-in-one/apisix/config.yaml](https://github.com/apache/apisix-docker/blob/master/all-in-one/apisix/config.yaml). It is mounted onto the container at runtime.
 
 - All in one Docker container for Apache apisix-dashboard
 
@@ -158,19 +151,6 @@ docker run -d \
 -v `pwd`/all-in-one/apisix-dashboard/conf.yaml:/usr/local/apisix-dashboard/conf/conf.yaml \
 apache/apisix-dashboard:whole
 ```
-
-## Useful commands
-
-Below are some useful commands which build, push, and tar your updated images.
-As an example, these are the commands for apisix-centos images:
-
-- ```make build-on-centos``` : Build apache/apisix:xx-centos image.
-
-- ```make push-on-centos```: Build and push apache/apisix:xx-centos image.
-
-- ```make save-centos-tar```: Save apache/apisix:xx-centos image to a tar archive located at ```./package```.
-
-Similar commands exist for apisix-alpine images and apisix dashboard. See [the makefile](/Makefile) for a full list of commands.
 
 ### Note
 

--- a/README.md
+++ b/README.md
@@ -141,9 +141,14 @@ docker pull apache/apisix:dev
 ```
 ## All commands
 
-**Centos**
+### APISIX
 
-  Supported arch: amd64, arm32v6, i386 
+* **All-in-one**
+  
+  ```make build-all-in-one```\
+  Build APISIX
+
+* **Centos**
   
   ```make build-on-centos``` \
   Build apache/apisix:xx-centos image. This can be used to build APISIX on centos.
@@ -154,15 +159,8 @@ docker pull apache/apisix:dev
   ```make save-centos-tar```\
   Save apache/apisix:xx-centos image to a tar archive located at ```./package``` . 
   
-  ```make build-dashboard-centos```\
-  Build apache/dashboard:tag image on centos. This can be used to build APISIX dashboard on centos.
   
-  ```make save-dashboard-centos-tar```\
-   Save apache/apisix-dashboard:tag image to a tar archive located at ```./package``` . 
-  
-**Alpine**
-
-  Supported arch: amd64, arm64
+* **Alpine**
   
   ```make build-on-alpine```\
   Build apache/apisix:xx-alpine image.
@@ -182,21 +180,31 @@ docker pull apache/apisix:dev
   ```make save-alpine-tar```\
   Save apache/apisix:xx-alpine image to a tar archive located at ```./package``` . 
   
+### APISIX Dashboard
+
+* **All-in-one**
+
+  ```make build-dashboard-all-in-one```\
+  Build APISIX-dashboard.
+  
+  ```make push-multiarch-dashboard```\
+  Build and push multiarch apache/dashboard:tag image. This can be used to build and push APISIX dashboard on centos and on alpine.
+
+* **Centos**
+  
+  ```make build-dashboard-centos```\
+  Build apache/dashboard:tag image on centos. This can be used to build APISIX dashboard on centos.
+  
+  ```make save-dashboard-centos-tar```\
+   Save apache/apisix-dashboard:tag image to a tar archive located at ```./package``` .
+  
+* **Alpine**
+  
   ```make build-dashboard-alpine```\
   Build apache/dashboard:tag image on alpine. This can be used to build APISIX dashboard on alpine.
   
   ```make save-dashboard-alpine-tar```\
   Save apache/apisix-dashboard:tag image to a tar archive located at ```./package``` . 
 
-**All-in-one**
 
-  Supported arch: amd64, arm64
-  
-  ```make build-all-in-one```\
-  Build APISIX.
-  
-  ```make build-dashboard-all-in-one```\
-  Build APISIX-dashboard.
-  
-  ```make push-multiarch-dashboard```\
-  Build and push multiarch apache/dashboard:tag image. This can be used to build and push APISIX dashboard on centos and on alpine.
+

--- a/README.md
+++ b/README.md
@@ -4,10 +4,9 @@ This repo includes:
 2. examples that show how to get APISIX and APISIX dashboard up and running. 
 3. a list of commands that allow users to easily build, save, and tar the docker images.
 
-## How To Build Images
+**Docker images are not official ASF releases but provided for convenience. Recommended usage is always to build the source.**
 
-**Note**: Docker images are not official ASF releases but provided for convenience. Recommended usage is always to build the source. \
-**Note**: The master branch is for the version of Apache APISIX 2.x. If you need a previous version, please build from the [v1.x](https://github.com/apache/apisix-docker/releases/tag/v1.x) tag.
+## How To Build Images
 
 The repo contains the following images:
 
@@ -36,6 +35,9 @@ make build-on-centos
 ```
 
 2. Build from master branch version, which has latest code(ONLY for the developer's convenience):
+
+**The master branch is for the version of Apache APISIX 2.x. If you need a previous version, please build from the [v1.x]       (https://github.com/apache/apisix-docker/releases/tag/v1.x) tag.**
+
 ```sh
 export APISIX_VERSION=master
 
@@ -163,7 +165,7 @@ As an example, these are the commands for apisix-centos images:
 
 -   ```make push-on-centos```: Build and push apache/apisix:xx-centos image.
 
--  ```make save-centos-tar```:  Save apache/apisix:xx-centos image to a tar archive located at ```./package``` . 
+-   ```make save-centos-tar```: Save apache/apisix:xx-centos image to a tar archive located at ```./package``` . 
 
 Similar commands exist for apisix-alpine images and apisix dashboard. See [the makefile](/Makefile) for a full list of commands. 
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 ## Summary
+
 This repo includes:
-1. docker images for APISIX and APISIX dashboard (on alpine and centos). 
-2. examples that show how to get APISIX and APISIX dashboard up and running. 
+1. docker images for APISIX and APISIX dashboard (on alpine and centos).
+2. examples that show how to get APISIX and APISIX dashboard up and running.
 3. a list of commands that allow users to easily build, save, and tar the docker images.
 
 **Docker images are not official ASF releases but provided for convenience. Recommended usage is always to build the source.**
@@ -36,7 +37,7 @@ make build-on-centos
 
 2. Build from master branch version, which has latest code(ONLY for the developer's convenience):
 
-**The master branch is for the version of Apache APISIX 2.x. If you need a previous version, please build from the [v1.x]       (https://github.com/apache/apisix-docker/releases/tag/v1.x) tag.**
+**The master branch is for the version of Apache APISIX 2.x. If you need a previous version, please build from the [v1.x]       (/releases/tag/v1.x) tag.**
 
 ```sh
 export APISIX_VERSION=master
@@ -90,7 +91,7 @@ The following example illustrates how to run APISIX and APISIX dashboard with do
     cd example
     docker-compose -p docker-apisix up -d
     ```
- 
+
 2. Check if APISIX is running properly by running this command and checking the response.
     ```
     curl "http://127.0.0.1:9080/apisix/admin/services/" -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1'
@@ -107,19 +108,20 @@ The following example illustrates how to run APISIX and APISIX dashboard with do
       }
     }
     ```
- 
+
 The example docker compose file defines several services: `apisix-dashboard, apisix, etcd, web1, web2, prometheus, and grafana`:
 `apisix-dashboard, apisix, etcd` are the essential services required for starting apisix-dashboard, apisix, etcd.
 `web1, web2` are sample backend services used for testing purposes.
 `prometheus, grafana` are services used for exposing metrics of the running services.
- It also creates a bridge network `apisix` which connects all services and a `etcd_data` volume used by the `etcd` service. 
+ It also creates a bridge network `apisix` which connects all services and a `etcd_data` volume used by the `etcd` service.
 
 All the services are configured by mounting external configuration files onto the containers: `./dashboard_conf/conf.yaml` defines the configs for `apisix-dashboard`; `./apisix_conf/conf.yaml` defines the configs for apisix. Similarly, configs for etcd, prometheus, and grafana are located in the corresponding conf.yaml files. If you want to use a config file from a different path, you need to modify the local config file path in the `volumes` entry under the corresponding service.
 
 ## Quick test with all dependencies in one Docker container
-A quick way to get APISIX running on alpine is to use the provided all-in-one docker images, which deploys all dependencies in one Docker container. 
 
-* All in one Docker container for Apache APISIX
+A quick way to get APISIX running on alpine is to use the provided all-in-one docker images, which deploys all dependencies in one Docker container.
+
+- All in one Docker container for Apache APISIX
 
 ```sh
 make build-all-in-one
@@ -131,7 +133,7 @@ docker run -d \
 apache/apisix:whole
 ```
 
-* All in one Docker container for Apache apisix-dashboard
+- All in one Docker container for Apache apisix-dashboard
 
 **The latest version of `apisix-dashboard` is 2.10 and can be used with APISIX 2.11.**
 
@@ -156,18 +158,19 @@ docker run -d \
 -v `pwd`/all-in-one/apisix-dashboard/conf.yaml:/usr/local/apisix-dashboard/conf/conf.yaml \
 apache/apisix-dashboard:whole
 ```
+
 ## Useful commands
 
 Below are some useful commands which build, push, and tar your updated images.
 As an example, these are the commands for apisix-centos images:
 
--   ```make build-on-centos``` : Build apache/apisix:xx-centos image. 
+- ```make build-on-centos``` : Build apache/apisix:xx-centos image.
 
--   ```make push-on-centos```: Build and push apache/apisix:xx-centos image.
+- ```make push-on-centos```: Build and push apache/apisix:xx-centos image.
 
--   ```make save-centos-tar```: Save apache/apisix:xx-centos image to a tar archive located at ```./package``` . 
+- ```make save-centos-tar```: Save apache/apisix:xx-centos image to a tar archive located at ```./package```.
 
-Similar commands exist for apisix-alpine images and apisix dashboard. See [the makefile](/Makefile) for a full list of commands. 
+Similar commands exist for apisix-alpine images and apisix dashboard. See [the makefile](/Makefile) for a full list of commands.
 
 ### Note
 

--- a/README.md
+++ b/README.md
@@ -140,11 +140,13 @@ At `0:00 UTC` every day, the APISIX `master` code will be automatically built an
 docker pull apache/apisix:dev
 ```
 ## All commands
-Commands supported by apisix-docker
-* Centos:\
-  Supported arch: amd64, arm32v6, i386 \
+
+**Centos**
+
+  Supported arch: amd64, arm32v6, i386 
+  
   ```make build-on-centos``` \
-  Build apache/apisix:xx-centos image. This command can be used to build apisix on centos.
+  Build apache/apisix:xx-centos image. This can be used to build APISIX on centos.
   
   ```make push-on-centos```\
   Build and push apache/apisix:xx-centos image.
@@ -158,10 +160,12 @@ Commands supported by apisix-docker
   ```make save-dashboard-centos-tar```\
    Save apache/apisix-dashboard:tag image to a tar archive located at ```./package``` . 
   
-* Alpine:\
-  Supported arch: amd64, arm64\
+**Alpine**
+
+  Supported arch: amd64, arm64
+  
   ```make build-on-alpine```\
-  Build apache/apisix:xx-alpine image.\
+  Build apache/apisix:xx-alpine image.
   
   ```make build-on-alpine-dev```\
   Build apache/apisix:xx-alpine-dev image.
@@ -170,7 +174,7 @@ Commands supported by apisix-docker
   Build apache/apisix:xx-alpine image (for Chinese)
   
   ```make build-on-alpine-local```\
-  Build apache/apisix:xx-alpine-local image. This command can be used to build image on local code.
+  Build apache/apisix:xx-alpine-local image. This can be used to build image on local code.
   
   ```make push-multiarch-on-alpine```\
   Push apache/apisix:xx-alpine image.
@@ -184,8 +188,10 @@ Commands supported by apisix-docker
   ```make save-dashboard-alpine-tar```\
   Save apache/apisix-dashboard:tag image to a tar archive located at ```./package``` . 
 
-* All-in-one:
-  Supported arch: amd64, arm64\
+**All-in-one**
+
+  Supported arch: amd64, arm64
+  
   ```make build-all-in-one```\
   Build APISIX.
   


### PR DESCRIPTION
Update README.md:
- add a **Summary** section, which briefly what this repo contains
- add doc for images in the beginning in **How to Build Images**
- add **Run With Docker-compose**
- add **Useful Commands**

Need info for: 

- supported platforms for each command

Any suggestion or fix is appreciated :)