### PR TITLE
fix: apply PCRE path fix to alpine-dev & all-in-one

### DIFF
--- a/all-in-one/apisix-dashboard/Dockerfile
+++ b/all-in-one/apisix-dashboard/Dockerfile
@@ -36,14 +36,12 @@ RUN set -x \
     pkgconfig \
     cmake \
     git \
-    pcre \
-    pcre-dev \
     openldap-dev \
     && mkdir ~/.luarocks \
     && luarocks config variables.OPENSSL_LIBDIR /usr/local/openresty/openssl/lib \
     && luarocks config variables.OPENSSL_INCDIR /usr/local/openresty/openssl/include \
     && git config --global url.https://github.com/.insteadOf git://github.com/ \
-    && luarocks install https://github.com/apache/apisix/raw/master/rockspec/apisix-${APISIX_VERSION}-0.rockspec --tree=/usr/local/apisix/deps \
+    && luarocks install https://github.com/apache/apisix/raw/master/rockspec/apisix-${APISIX_VERSION}-0.rockspec --tree=/usr/local/apisix/deps PCRE_DIR=/usr/local/openresty/pcre \
     && cp -v /usr/local/apisix/deps/lib/luarocks/rocks-5.1/apisix/${APISIX_VERSION}-0/bin/apisix /usr/bin/ \
     && (if [ "$APISIX_VERSION" = "master" ] || [ "$APISIX_VERSION" \> "2.2" ]; then echo 'use shell ';else bin='#! /usr/local/openresty/luajit/bin/luajit\npackage.path = "/usr/local/apisix/?.lua;" .. package.path'; sed -i "1s@.*@$bin@" /usr/bin/apisix ; fi;) \
     && mv /usr/local/apisix/deps/share/lua/5.1/apisix /usr/local/apisix \

--- a/all-in-one/apisix/Dockerfile
+++ b/all-in-one/apisix/Dockerfile
@@ -40,11 +40,9 @@ RUN set -x \
         curl \
         openssl \
         git \
-        pcre \
-        pcre-dev \
         openldap-dev \
     && git config --global url.https://github.com/.insteadOf git://github.com/ \
-    && luarocks install https://github.com/apache/apisix/raw/master/rockspec/apisix-${APISIX_VERSION}-0.rockspec --tree=/usr/local/apisix/deps \
+    && luarocks install https://github.com/apache/apisix/raw/master/rockspec/apisix-${APISIX_VERSION}-0.rockspec --tree=/usr/local/apisix/deps PCRE_DIR=/usr/local/openresty/pcre \
     && cp -v /usr/local/apisix/deps/lib/luarocks/rocks-5.1/apisix/${APISIX_VERSION}-0/bin/apisix /usr/bin/ \
     && (function ver_lt { [ "$1" = "$2" ] && return 1 || [ "$1" = "`echo -e "$1\n$2" | sort -V | head -n1`" ]; };  if [ "$APISIX_VERSION" = "master" ] || ver_lt 2.2.0 $APISIX_VERSION; then echo 'use shell ';else bin='#! /usr/local/openresty/luajit/bin/luajit\npackage.path = "/usr/local/apisix/?.lua;" .. package.path'; sed -i "1s@.*@$bin@" /usr/bin/apisix ; fi;) \
     && mv /usr/local/apisix/deps/share/lua/5.1/apisix /usr/local/apisix \

--- a/alpine-dev/Dockerfile
+++ b/alpine-dev/Dockerfile
@@ -34,8 +34,6 @@ RUN set -x \
         curl \
         openssl \
         git \
-        pcre \
-        pcre-dev \
         openldap-dev \
     && luarocks install https://github.com/apache/apisix/raw/master/rockspec/apisix-master-0.rockspec --tree=/usr/local/apisix/deps PCRE_DIR=/usr/local/openresty/pcre \
     && cp -v /usr/local/apisix/deps/lib/luarocks/rocks-5.1/apisix/master-0/bin/apisix /usr/bin/ \

--- a/alpine-dev/Dockerfile
+++ b/alpine-dev/Dockerfile
@@ -37,7 +37,7 @@ RUN set -x \
         pcre \
         pcre-dev \
         openldap-dev \
-    && luarocks install https://github.com/apache/apisix/raw/master/rockspec/apisix-master-0.rockspec --tree=/usr/local/apisix/deps \
+    && luarocks install https://github.com/apache/apisix/raw/master/rockspec/apisix-master-0.rockspec --tree=/usr/local/apisix/deps PCRE_DIR=/usr/local/openresty/pcre \
     && cp -v /usr/local/apisix/deps/lib/luarocks/rocks-5.1/apisix/master-0/bin/apisix /usr/bin/ \
     && mv /usr/local/apisix/deps/share/lua/5.1/apisix /usr/local/apisix \
     && apk del .builddeps \


### PR DESCRIPTION
This fix is from https://github.com/apache/apisix-docker/pull/287.
Look like it is missing in the dev image

Reported in https://the-asf.slack.com/archives/CUC5MN17A/p1652951422223499?thread_ts=1652868150.081189&cid=CUC5MN17A
Signed-off-by: spacewander <spacewanderlzx@gmail.com>