### PR TITLE
fix(grafana): fix issues #329

### DIFF
--- a/example/apisix_conf/config.yaml
+++ b/example/apisix_conf/config.yaml
@@ -35,6 +35,13 @@ apisix:
   control:
     ip: "0.0.0.0"
     port: 9092
+  security:
+    access_control_allow_origin: "http://httpbin.org"
+    access_control_allow_credentials: true          # support using custom cors configration
+    access_control_allow_headers: "Authorization"
+    access_control-allow_methods: "*"
+    x_frame_options: "deny"
+    content_security_policy: "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; frame-src xxx.xxx.xxx.xxx:3000"  # Please note to fill in your ip address here.
 
 etcd:
   host:                           # it's possible to define multiple etcd hosts addresses of the same etcd cluster.


### PR DESCRIPTION
As title says.

This PR aimed to solve #329 .

The source of this problem is from the APISIX Dashboard project. This is because it has updated the CSP (content security policy) feature. This caused the site to need to configure some security policy in order to display properly.

One more note, the Dashboard project's default configuration file has this optional configuration added, but it was problematic, so I submitted a [PR](https://github.com/apache/apisix-dashboard/pull/2548). You can see its default configuration options via this [link](https://github.com/apache/apisix-dashboard/blob/master/api/conf/conf.yaml#:~:text=%23-,security%3A,-%23%20%20%20access_control_allow_origin%3A) to see its default configuration options.