### PR TITLE
chore: install apisix via package name instead of url

### DIFF
--- a/centos/Dockerfile
+++ b/centos/Dockerfile
@@ -21,7 +21,7 @@ ARG APISIX_VERSION=2.15.0
 LABEL apisix_version="${APISIX_VERSION}"
 
 RUN yum install -y https://repos.apiseven.com/packages/centos/apache-apisix-repo-1.0-1.noarch.rpm \
-	&& yum install -y https://repos.apiseven.com/packages/centos/7/x86_64/apisix-$APISIX_VERSION-0.el7.x86_64.rpm \
+	&& yum install -y apisix-${APISIX_VERSION} \
 	&& yum clean all \
 	&& sed -i 's/PASS_MAX_DAYS\t99999/PASS_MAX_DAYS\t60/g' /etc/login.defs
 


### PR DESCRIPTION
Install apisix by package name for better platform (x86_86 or aarch64) compatibility.