### PR TITLE
chore: sync APISIX use 9180 as default port of admin API

### DIFF
--- a/.github/workflows/apisix-docker-dev-test.yaml
+++ b/.github/workflows/apisix-docker-dev-test.yaml
@@ -1,12 +1,13 @@
 name: APISIX Docker dev Test
 
 on:
+  schedule:
+    - cron: "0 1 * * *"
   push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
+    branches: [master]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
 
 jobs:
   build:

--- a/.github/workflows/apisix-docker-dev-test.yaml
+++ b/.github/workflows/apisix-docker-dev-test.yaml
@@ -1,4 +1,4 @@
-name: APISIX Docker Test
+name: APISIX Docker dev Test
 
 on:
   push:
@@ -14,13 +14,12 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - alpine
-          - centos
-          - debian
+          - debian-dev
 
     runs-on: ubuntu-latest
     env:
-      APISIX_DOCKER_TAG: 2.15.0-${{ matrix.platform }}
+      APISIX_VERSION=master
+      APISIX_DOCKER_TAG: master-${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v2
 
@@ -35,7 +34,7 @@ jobs:
         run: |
           grep -C 3 '\[error\]' example/apisix_log/error.log && exit 1
 
-          curl http://127.0.0.1:9080/apisix/admin/routes/1 \
+          curl http://127.0.0.1:9180/apisix/admin/routes/1 \
           -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
             {
             "uri": "/get",

--- a/.github/workflows/apisix-docker-dev-test.yaml
+++ b/.github/workflows/apisix-docker-dev-test.yaml
@@ -19,7 +19,7 @@ jobs:
 
     runs-on: ubuntu-latest
     env:
-      APISIX_VERSION=master
+      APISIX_VERSION: master
       APISIX_DOCKER_TAG: master-${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v2

--- a/compose/docker-compose.yaml
+++ b/compose/docker-compose.yaml
@@ -27,6 +27,7 @@ services:
     depends_on:
       - etcd
     ports:
+      - "9180:9180/tcp"
       - "9080:9080/tcp"
       - "9091:9091/tcp"
       - "9443:9443/tcp"


### PR DESCRIPTION
Because of a break change in APISIX, we have to use 9180 as the request port for the admin api.

The current dev image and other official version images use a same test task, which makes it impossible for us to adjust the admin api port in CI, because the official image is the release version and uses port 9180.

So, I split the CI of the dev image separately, it will run when the dev image is released.