### PR TITLE
chore: remove debian IMAGE_BASE

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -17,7 +17,6 @@
 
 FROM debian:bullseye-slim
 
-ARG TARGETARCH
 ARG APISIX_VERSION=2.15.0
 
 RUN set -ex; \

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ARG IMAGE_BASE="debian"
-ARG IMAGE_TAG="bullseye"
 
 FROM debian:bullseye-slim
 

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -17,7 +17,7 @@
 ARG IMAGE_BASE="debian"
 ARG IMAGE_TAG="bullseye"
 
-FROM ${IMAGE_BASE}:${IMAGE_TAG}-slim
+FROM debian:bullseye-slim
 
 ARG TARGETARCH
 ARG APISIX_VERSION=2.15.0


### PR DESCRIPTION
Use a fixed version of the base image, so that we can use the [bashbrew](https://github.com/docker-library/bashbrew) tool to build the image, which is the requirement of the official docker image