### PR TITLE
feat: upgrade the version of apisix-base

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -18,7 +18,7 @@
 ARG ENABLE_PROXY=false
 
 # Build Apache APISIX
-FROM api7/apisix-base:1.21.4.1.1
+FROM api7/apisix-base:1.21.4.1.2
 
 ARG APISIX_VERSION=2.15.0
 LABEL apisix_version="${APISIX_VERSION}"


### PR DESCRIPTION
Fixed CVE-* by alpine 3.15.6

trivy scan: Total: 1 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)