### PR TITLE
fix: example unavailable

### DIFF
--- a/.github/workflows/apisix-docker-example-test.yaml
+++ b/.github/workflows/apisix-docker-example-test.yaml
@@ -26,7 +26,7 @@ jobs:
           sleep 30
           grep -C 3 '\[error\]' example/apisix_log/error.log && exit 1
 
-          curl http://127.0.0.1:9080/apisix/admin/routes/1 \
+          curl http://127.0.0.1:9180/apisix/admin/routes/1 \
           -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
             {
             "uri": "/get",

--- a/.github/workflows/apisix_all_in_one_ci.yaml
+++ b/.github/workflows/apisix_all_in_one_ci.yaml
@@ -26,7 +26,7 @@ jobs:
           docker run -v `pwd`/all-in-one/apisix/config.yaml:/usr/local/apisix/conf/config.yaml -p 9180:9180 -p 9080:9080 -p 2379:2379 --name apisix -d apache/apisix:whole
           docker logs apisix
           sudo netstat -lntp
-          docker exec -it apisix cat /usr/local/apisix/logs/error.log
+          docker exec -i apisix cat /usr/local/apisix/logs/error.log
 
       - name: Test
         run: |

--- a/.github/workflows/apisix_all_in_one_ci.yaml
+++ b/.github/workflows/apisix_all_in_one_ci.yaml
@@ -17,6 +17,12 @@ jobs:
       - name: Build and Test
         run: |
           docker build -t apache/apisix:whole -f ./all-in-one/apisix/Dockerfile .
+
+      - name: Setup upterm session
+        uses: lhotari/action-upterm@v1
+
+      - name: test
+        run: |
           docker run -v `pwd`/all-in-one/apisix/config.yaml:/usr/local/apisix/conf/config.yaml -p 9180:9180 -p 9080:9080 -p 2379:2379 --name apisix -d apache/apisix:whole
           sleep 30
           curl http://127.0.0.1:9180/apisix/admin/schema/service -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1'

--- a/.github/workflows/apisix_all_in_one_ci.yaml
+++ b/.github/workflows/apisix_all_in_one_ci.yaml
@@ -17,15 +17,9 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Build
+      - name: Build and Test
         run: |
           docker build -t apache/apisix:whole -f ./all-in-one/apisix/Dockerfile .
-
-      - name: Start
-        run: |
           docker run -v `pwd`/all-in-one/apisix/config.yaml:/usr/local/apisix/conf/config.yaml -p 9180:9180 -p 9080:9080 -p 2379:2379 --name apisix -d apache/apisix:whole
-
-      - name: Test
-        run: |
           sleep 30
           curl http://127.0.0.1:9180/apisix/admin/schema/service -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1'

--- a/.github/workflows/apisix_all_in_one_ci.yaml
+++ b/.github/workflows/apisix_all_in_one_ci.yaml
@@ -27,7 +27,7 @@ jobs:
       
       # Debug via SSH if previous steps failed
       - name: Set up tmate session
-        uses: ./.github/actions/action-tmate
+        uses: ./.github/action-tmate
         with:
           timeout-minutes: 15
 

--- a/.github/workflows/apisix_all_in_one_ci.yaml
+++ b/.github/workflows/apisix_all_in_one_ci.yaml
@@ -18,8 +18,8 @@ jobs:
         run: |
           docker build -t apache/apisix:whole -f ./all-in-one/apisix/Dockerfile .
 
-      - name: Setup upterm session
-        uses: lhotari/action-upterm@v1
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
 
       - name: test
         run: |

--- a/.github/workflows/apisix_all_in_one_ci.yaml
+++ b/.github/workflows/apisix_all_in_one_ci.yaml
@@ -14,15 +14,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Build and Test
+      - name: Build
         run: |
           docker build -t apache/apisix:whole -f ./all-in-one/apisix/Dockerfile .
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-
-      - name: test
+      - name: Start
         run: |
           docker run -v `pwd`/all-in-one/apisix/config.yaml:/usr/local/apisix/conf/config.yaml -p 9180:9180 -p 9080:9080 -p 2379:2379 --name apisix -d apache/apisix:whole
+      
+      - name: Test
+        run: |
           sleep 30
           curl http://127.0.0.1:9180/apisix/admin/schema/service -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1'

--- a/.github/workflows/apisix_all_in_one_ci.yaml
+++ b/.github/workflows/apisix_all_in_one_ci.yaml
@@ -12,7 +12,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Check out code
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
 
       - name: Build
         run: |
@@ -22,6 +25,12 @@ jobs:
         run: |
           docker run -v `pwd`/all-in-one/apisix/config.yaml:/usr/local/apisix/conf/config.yaml -p 9180:9180 -p 9080:9080 -p 2379:2379 --name apisix -d apache/apisix:whole
       
+      # Debug via SSH if previous steps failed
+      - name: Set up tmate session
+        uses: ./.github/actions/action-tmate
+        with:
+          timeout-minutes: 15
+
       - name: Test
         run: |
           sleep 30

--- a/.github/workflows/apisix_all_in_one_ci.yaml
+++ b/.github/workflows/apisix_all_in_one_ci.yaml
@@ -24,12 +24,8 @@ jobs:
       - name: Start
         run: |
           docker run -v `pwd`/all-in-one/apisix/config.yaml:/usr/local/apisix/conf/config.yaml -p 9180:9180 -p 9080:9080 -p 2379:2379 --name apisix -d apache/apisix:whole
-      
-      # Debug via SSH if previous steps failed
-      - name: Set up tmate session
-        uses: ./.github/action-tmate
-        with:
-          timeout-minutes: 15
+          docker logs apisix
+          sudo netstat -lntp
 
       - name: Test
         run: |

--- a/.github/workflows/apisix_all_in_one_ci.yaml
+++ b/.github/workflows/apisix_all_in_one_ci.yaml
@@ -26,6 +26,7 @@ jobs:
           docker run -v `pwd`/all-in-one/apisix/config.yaml:/usr/local/apisix/conf/config.yaml -p 9180:9180 -p 9080:9080 -p 2379:2379 --name apisix -d apache/apisix:whole
           docker logs apisix
           sudo netstat -lntp
+          docker exec -it apisix cat /usr/local/apisix/logs/error.log
 
       - name: Test
         run: |

--- a/.github/workflows/apisix_all_in_one_ci.yaml
+++ b/.github/workflows/apisix_all_in_one_ci.yaml
@@ -17,6 +17,6 @@ jobs:
       - name: Build and Test
         run: |
           docker build -t apache/apisix:whole -f ./all-in-one/apisix/Dockerfile .
-          docker run -v `pwd`/all-in-one/apisix/config.yaml:/usr/local/apisix/conf/config.yaml -p 9080:9080 -p 2379:2379 --name apisix -d apache/apisix:whole
+          docker run -v `pwd`/all-in-one/apisix/config.yaml:/usr/local/apisix/conf/config.yaml -p 9180:9180 -p 9080:9080 -p 2379:2379 --name apisix -d apache/apisix:whole
           sleep 30
-          curl http://127.0.0.1:9080/apisix/admin/schema/service -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1'
+          curl http://127.0.0.1:9180/apisix/admin/schema/service -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1'

--- a/.github/workflows/apisix_all_in_one_ci.yaml
+++ b/.github/workflows/apisix_all_in_one_ci.yaml
@@ -12,10 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Check out code
-        uses: actions/checkout@v3
-        with:
-          submodules: recursive
+      - uses: actions/checkout@v3
 
       - name: Build and Test
         run: |

--- a/.github/workflows/apisix_all_in_one_ci.yaml
+++ b/.github/workflows/apisix_all_in_one_ci.yaml
@@ -24,9 +24,6 @@ jobs:
       - name: Start
         run: |
           docker run -v `pwd`/all-in-one/apisix/config.yaml:/usr/local/apisix/conf/config.yaml -p 9180:9180 -p 9080:9080 -p 2379:2379 --name apisix -d apache/apisix:whole
-          docker logs apisix
-          sudo netstat -lntp
-          docker exec -i apisix cat /usr/local/apisix/logs/error.log
 
       - name: Test
         run: |

--- a/.github/workflows/apisix_push_docker_hub.yaml
+++ b/.github/workflows/apisix_push_docker_hub.yaml
@@ -30,7 +30,7 @@ jobs:
         run: |
           grep -C 3 '\[error\]' compose/apisix_log/error.log && exit 1
 
-          curl http://127.0.0.1:9080/apisix/admin/routes/1 \
+          curl http://127.0.0.1:9180/apisix/admin/routes/1 \
           -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
             {
             "uri": "/get",

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule ".github/action-tmate"]
-	path = .github/action-tmate
-	url = https://github.com/mxschmitt/action-tmate

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".github/actions/action-tmate"]
+	path = .github/actions/action-tmate
+	url = https://github.com/mxschmitt/action-tmate

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule ".github/actions/action-tmate"]
-	path = .github/actions/action-tmate
+[submodule ".github/action-tmate"]
+	path = .github/action-tmate
 	url = https://github.com/mxschmitt/action-tmate

--- a/all-in-one/apisix/Dockerfile
+++ b/all-in-one/apisix/Dockerfile
@@ -20,36 +20,8 @@ ARG APISIX_VERSION=2.99.0
 ARG ETCD_VERSION=v3.5.4
 
 # Build Apache APISIX
-FROM api7/apisix-base:1.21.4.1.2 AS production-stage
+FROM apache/apisix:${APISIX_VERSION}-debian
 
-ARG APISIX_VERSION
-LABEL apisix_version="${APISIX_VERSION}"
-
-ARG ENABLE_PROXY
-
-RUN set -x \
-    && (test "${ENABLE_PROXY}" != "true" || /bin/sed -i 's,http://dl-cdn.alpinelinux.org,https://mirrors.aliyun.com,g' /etc/apk/repositories) \
-    && apk add --no-cache --virtual .builddeps \
-        build-base \
-        automake \
-        autoconf \
-        libtool \
-        pkgconfig \
-        cmake \
-        unzip \
-        curl \
-        openssl \
-        git \
-        openldap-dev \
-    && git config --global url.https://github.com/.insteadOf git://github.com/ \
-    && luarocks install https://github.com/apache/apisix/raw/master/rockspec/apisix-${APISIX_VERSION}-0.rockspec --tree=/usr/local/apisix/deps PCRE_DIR=/usr/local/openresty/pcre \
-    && cp -v /usr/local/apisix/deps/lib/luarocks/rocks-5.1/apisix/${APISIX_VERSION}-0/bin/apisix /usr/bin/ \
-    && (function ver_lt { [ "$1" = "$2" ] && return 1 || [ "$1" = "`echo -e "$1\n$2" | sort -V | head -n1`" ]; };  if [ "$APISIX_VERSION" = "master" ] || ver_lt 2.2.0 $APISIX_VERSION; then echo 'use shell ';else bin='#! /usr/local/openresty/luajit/bin/luajit\npackage.path = "/usr/local/apisix/?.lua;" .. package.path'; sed -i "1s@.*@$bin@" /usr/bin/apisix ; fi;) \
-    && mv /usr/local/apisix/deps/share/lua/5.1/apisix /usr/local/apisix \
-    && apk del .builddeps build-base make unzip
-
-# Build etcd
-FROM alpine:3.14 AS etcd-stage
 
 ARG ETCD_VERSION
 LABEL etcd_version="${ETCD_VERSION}"
@@ -58,25 +30,10 @@ WORKDIR /tmp
 
 RUN wget https://github.com/etcd-io/etcd/releases/download/${ETCD_VERSION}/etcd-${ETCD_VERSION}-linux-amd64.tar.gz \
     && tar -zxvf etcd-${ETCD_VERSION}-linux-amd64.tar.gz \
-    && ln -s etcd-${ETCD_VERSION}-linux-amd64 etcd
+    && mv etcd-${ETCD_VERSION}-linux-amd64/* /usr/bin/
 
-# Finally combine all the resources into one image
-FROM alpine:3.14 AS last-stage
-
-ARG ENABLE_PROXY
-# add runtime for Apache APISIX
-RUN set -x \
-    && (test "${ENABLE_PROXY}" != "true" || /bin/sed -i 's,http://dl-cdn.alpinelinux.org,https://mirrors.aliyun.com,g' /etc/apk/repositories) \
-    && apk add --no-cache bash libstdc++ curl openldap-dev
 
 WORKDIR /usr/local/apisix
-
-COPY --from=production-stage /usr/local/openresty/ /usr/local/openresty/
-COPY --from=production-stage /usr/local/apisix/ /usr/local/apisix/
-COPY --from=production-stage /usr/bin/apisix /usr/bin/apisix
-
-COPY --from=etcd-stage /tmp/etcd/etcd /usr/bin/etcd
-COPY --from=etcd-stage /tmp/etcd/etcdctl /usr/bin/etcdctl
 
 ENV PATH=$PATH:/usr/local/openresty/luajit/bin:/usr/local/openresty/nginx/sbin:/usr/local/openresty/bin
 

--- a/all-in-one/apisix/Dockerfile
+++ b/all-in-one/apisix/Dockerfile
@@ -17,7 +17,7 @@
 
 ARG ENABLE_PROXY=false
 ARG APISIX_VERSION=2.99.0
-ARG ETCD_VERSION=v3.4.14
+ARG ETCD_VERSION=v3.5.4
 
 # Build Apache APISIX
 FROM api7/apisix-base:1.21.4.1.2 AS production-stage

--- a/all-in-one/apisix/Dockerfile
+++ b/all-in-one/apisix/Dockerfile
@@ -49,7 +49,7 @@ RUN set -x \
     && apk del .builddeps build-base make unzip
 
 # Build etcd
-FROM alpine:3.13 AS etcd-stage
+FROM alpine:3.14 AS etcd-stage
 
 ARG ETCD_VERSION
 LABEL etcd_version="${ETCD_VERSION}"
@@ -61,7 +61,7 @@ RUN wget https://github.com/etcd-io/etcd/releases/download/${ETCD_VERSION}/etcd-
     && ln -s etcd-${ETCD_VERSION}-linux-amd64 etcd
 
 # Finally combine all the resources into one image
-FROM alpine:3.13 AS last-stage
+FROM alpine:3.14 AS last-stage
 
 ARG ENABLE_PROXY
 # add runtime for Apache APISIX

--- a/all-in-one/apisix/Dockerfile
+++ b/all-in-one/apisix/Dockerfile
@@ -20,7 +20,7 @@ ARG APISIX_VERSION=2.99.0
 ARG ETCD_VERSION=v3.4.14
 
 # Build Apache APISIX
-FROM api7/apisix-base:1.21.4.1.1 AS production-stage
+FROM api7/apisix-base:1.21.4.1.2 AS production-stage
 
 ARG APISIX_VERSION
 LABEL apisix_version="${APISIX_VERSION}"
@@ -80,7 +80,7 @@ COPY --from=etcd-stage /tmp/etcd/etcdctl /usr/bin/etcdctl
 
 ENV PATH=$PATH:/usr/local/openresty/luajit/bin:/usr/local/openresty/nginx/sbin:/usr/local/openresty/bin
 
-EXPOSE 9080 9443 2379 2380
+EXPOSE 9180 9080 9443 2379 2380
 
 CMD ["sh", "-c", "(nohup etcd >/tmp/etcd.log 2>&1 &) && sleep 10 && /usr/bin/apisix init && /usr/bin/apisix init_etcd && /usr/local/openresty/bin/openresty -p /usr/local/apisix -g 'daemon off;'"]
 

--- a/all-in-one/apisix/config.yaml
+++ b/all-in-one/apisix/config.yaml
@@ -24,6 +24,11 @@ deployment:
     allow_admin:               # http://nginx.org/en/docs/http/ngx_http_access_module.html#allow
       - 0.0.0.0/0              # We need to restrict ip access rules for security. 0.0.0.0/0 is for test.
 
+  admin_key:
+      - name: "admin"
+        key: edd1c9f034335f136f87ad84b625c8f1
+        role: admin                 # admin: manage all configuration data
+
 plugin_attr:
   prometheus:
     export_addr:

--- a/all-in-one/apisix/config.yaml
+++ b/all-in-one/apisix/config.yaml
@@ -25,9 +25,9 @@ deployment:
       - 0.0.0.0/0              # We need to restrict ip access rules for security. 0.0.0.0/0 is for test.
 
   admin_key:
-      - name: "admin"
-        key: edd1c9f034335f136f87ad84b625c8f1
-        role: admin                 # admin: manage all configuration data
+    - name: "admin"
+      key: edd1c9f034335f136f87ad84b625c8f1
+      role: admin                 # admin: manage all configuration data
 
 plugin_attr:
   prometheus:

--- a/all-in-one/apisix/config.yaml
+++ b/all-in-one/apisix/config.yaml
@@ -19,8 +19,10 @@ apisix:
   node_listen: 9080              # APISIX listening port
   enable_ipv6: false
 
-  allow_admin:                  # http://nginx.org/en/docs/http/ngx_http_access_module.html#allow
-    - 0.0.0.0/0              # We need to restrict ip access rules for security. 0.0.0.0/0 is for test.
+deployment:
+  admin:
+    allow_admin:               # http://nginx.org/en/docs/http/ngx_http_access_module.html#allow
+      - 0.0.0.0/0              # We need to restrict ip access rules for security. 0.0.0.0/0 is for test.
 
 plugin_attr:
   prometheus:

--- a/alpine-dev/Dockerfile
+++ b/alpine-dev/Dockerfile
@@ -17,7 +17,7 @@
 
 ARG ENABLE_PROXY=false
 
-FROM api7/apisix-base:1.21.4.1.1 AS production-stage
+FROM api7/apisix-base:1.21.4.1.2 AS production-stage
 
 ARG ENABLE_PROXY
 RUN set -x \
@@ -53,7 +53,7 @@ WORKDIR /usr/local/apisix
 
 ENV PATH=$PATH:/usr/local/openresty/luajit/bin:/usr/local/openresty/nginx/sbin:/usr/local/openresty/bin
 
-EXPOSE 9080 9443
+EXPOSE 9180 9080 9443
 
 CMD ["sh", "-c", "/usr/bin/apisix init && /usr/bin/apisix init_etcd && /usr/local/openresty/bin/openresty -p /usr/local/apisix -g 'daemon off;'"]
 

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -58,7 +58,7 @@ WORKDIR /usr/local/apisix
 
 ENV PATH=$PATH:/usr/local/openresty/luajit/bin:/usr/local/openresty/nginx/sbin:/usr/local/openresty/bin
 
-EXPOSE 9080 9443
+EXPOSE 9180 9080 9443
 
 CMD ["sh", "-c", "/usr/bin/apisix init && /usr/bin/apisix init_etcd && /usr/local/openresty/bin/openresty -p /usr/local/apisix -g 'daemon off;'"]
 

--- a/compose/apisix_conf/release/config.yaml
+++ b/compose/apisix_conf/release/config.yaml
@@ -19,16 +19,18 @@ apisix:
   node_listen: 9080              # APISIX listening port
   enable_ipv6: false
 
-  allow_admin:                  # http://nginx.org/en/docs/http/ngx_http_access_module.html#allow
-    - 0.0.0.0/0              # We need to restrict ip access rules for security. 0.0.0.0/0 is for test.
+deployment:
+  admin:
+    allow_admin:               # http://nginx.org/en/docs/http/ngx_http_access_module.html#allow
+      - 0.0.0.0/0              # We need to restrict ip access rules for security. 0.0.0.0/0 is for test.
 
-  admin_key:
-    - name: "admin"
-      key: edd1c9f034335f136f87ad84b625c8f1
-      role: admin                 # admin: manage all configuration data
+    admin_key:
+      - name: "admin"
+        key: edd1c9f034335f136f87ad84b625c8f1
+        role: admin                 # admin: manage all configuration data
 
-etcd:
-  host:                           # it's possible to define multiple etcd hosts addresses of the same etcd cluster.
-    - "http://etcd:2379"     # multiple etcd address
-  prefix: "/apisix"               # apisix configurations prefix
-  timeout: 30                     # 30 seconds
+  etcd:
+    host:                           # it's possible to define multiple etcd hosts addresses of the same etcd cluster.
+      - "http://etcd:2379"          # multiple etcd address
+    prefix: "/apisix"               # apisix configurations prefix
+    timeout: 30                     # 30 seconds

--- a/compose/docker-compose-release.yaml
+++ b/compose/docker-compose-release.yaml
@@ -27,6 +27,7 @@ services:
     depends_on:
       - etcd
     ports:
+      - "9180:9180/tcp"
       - "9080:9080/tcp"
       - "9091:9091/tcp"
       - "9443:9443/tcp"

--- a/example/apisix_conf/config.yaml
+++ b/example/apisix_conf/config.yaml
@@ -19,28 +19,30 @@ apisix:
   node_listen: 9080              # APISIX listening port
   enable_ipv6: false
 
-  allow_admin:                  # http://nginx.org/en/docs/http/ngx_http_access_module.html#allow
-    - 0.0.0.0/0              # We need to restrict ip access rules for security. 0.0.0.0/0 is for test.
-
-  admin_key:
-    - name: "admin"
-      key: edd1c9f034335f136f87ad84b625c8f1
-      role: admin                 # admin: manage all configuration data
-                                  # viewer: only can view configuration data
-    - name: "viewer"
-      key: 4054f7cf07e344346cd3f287985e76a2
-      role: viewer
-  
   enable_control: true
   control:
     ip: "0.0.0.0"
     port: 9092
 
-etcd:
-  host:                           # it's possible to define multiple etcd hosts addresses of the same etcd cluster.
-    - "http://etcd:2379"     # multiple etcd address
-  prefix: "/apisix"               # apisix configurations prefix
-  timeout: 30                     # 30 seconds
+deployment:
+  admin:
+    allow_admin:               # http://nginx.org/en/docs/http/ngx_http_access_module.html#allow
+      - 0.0.0.0/0              # We need to restrict ip access rules for security. 0.0.0.0/0 is for test.
+
+    admin_key:
+      - name: "admin"
+        key: edd1c9f034335f136f87ad84b625c8f1
+        role: admin                 # admin: manage all configuration data
+
+      - name: "viewer"
+        key: 4054f7cf07e344346cd3f287985e76a2
+        role: viewer
+
+  etcd:
+    host:                           # it's possible to define multiple etcd hosts addresses of the same etcd cluster.
+      - "http://etcd:2379"          # multiple etcd address
+    prefix: "/apisix"               # apisix configurations prefix
+    timeout: 30                     # 30 seconds
 
 plugin_attr:
   prometheus:

--- a/example/docker-compose-arm64.yml
+++ b/example/docker-compose-arm64.yml
@@ -37,6 +37,7 @@ services:
     depends_on:
       - etcd
     ports:
+      - "9180:9180/tcp"
       - "9080:9080/tcp"
       - "9091:9091/tcp"
       - "9443:9443/tcp"

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -38,6 +38,7 @@ services:
       - etcd
     ##network_mode: host
     ports:
+      - "9180:9180/tcp"
       - "9080:9080/tcp"
       - "9091:9091/tcp"
       - "9443:9443/tcp"


### PR DESCRIPTION
Fixes:
https://github.com/apache/apisix/issues/8002
https://github.com/apache/apisix-docker/issues/367

After APISIX released the 2.99.0 version of the image, some configurations were incompatible, causing the example to fail to start normally.