### PR TITLE
fix: wrong etcd advertise url

### DIFF
--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -54,7 +54,7 @@ services:
     environment:
       ETCD_ENABLE_V2: "true"
       ALLOW_NONE_AUTHENTICATION: "yes"
-      ETCD_ADVERTISE_CLIENT_URLS: "http://0.0.0.0:2379"
+      ETCD_ADVERTISE_CLIENT_URLS: "http://etcd:2379"
       ETCD_LISTEN_CLIENT_URLS: "http://0.0.0.0:2379"
     ports:
       - "2379:2379/tcp"


### PR DESCRIPTION
The etcd advertise client URL is used to inform the etcd client of the external URL of each node of its cluster, and our example sets it to `0.0.0.0:2379`, **which is clearly wrong**. We need to change it to the hostname of the etcd container `etcd`.

When this option is misconfigured, it will mislead the grpc load balancer included in the etcd client, which will try to connect to that non-existent server `0.0.0.0:2379`.