### PR TITLE
feat: bump APISIX Dashboard to 2.15.0

### DIFF
--- a/.github/workflows/dashboard_all_in_one_ci.yaml
+++ b/.github/workflows/dashboard_all_in_one_ci.yaml
@@ -13,14 +13,14 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      APISIX_DASHBOARD_BRANCH: "2.14.0" # GitHub release tag id
+      APISIX_DASHBOARD_VERSION: "2.15.0" # in semver
     
     steps:
       - uses: actions/checkout@v2
 
       - name: Build and Test
         run: |
-          docker build -t apache/apisix-dashboard:whole --build-arg APISIX_DASHBOARD_VERSION=v${APISIX_DASHBOARD_BRANCH} -f ./all-in-one/apisix-dashboard/Dockerfile .
+          docker build -t apache/apisix-dashboard:whole --build-arg APISIX_DASHBOARD_TAG=v${APISIX_DASHBOARD_VERSION} -f ./all-in-one/apisix-dashboard/Dockerfile .
           docker run -v `pwd`/all-in-one/apisix/config.yaml:/usr/local/apisix/conf/config.yaml -v `pwd`/all-in-one/apisix-dashboard/conf.yaml:/usr/local/apisix-dashboard/conf/conf.yaml -p 9080:9080 -p 2379:2379 -p 9000:9000 -d apache/apisix-dashboard:whole
           sleep 30
           curl http://127.0.0.1:9080/apisix/admin/schema/service -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1'

--- a/.github/workflows/dashboard_push_docker_hub.yaml
+++ b/.github/workflows/dashboard_push_docker_hub.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      APISIX_DASHBOARD_TAG: "2.14.0"
+      APISIX_DASHBOARD_VERSION: "2.15.0" # in semver
 
     steps:
       - name: Check out the repo

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ MAX_APISIX_VERSION ?= 3.0.0
 IMAGE_NAME = apache/apisix
 IMAGE_TAR_NAME = apache_apisix
 
-APISIX_DASHBOARD_VERSION ?= 2.14.0
+APISIX_DASHBOARD_VERSION ?= $(shell echo ${APISIX_DASHBOARD_VERSION:=2.15.0})
 APISIX_DASHBOARD_IMAGE_NAME = apache/apisix-dashboard
 APISIX_DASHBOARD_IMAGE_TAR_NAME = apache_apisix_dashboard
 
@@ -205,39 +205,23 @@ save-debian-tar:
 	@$(call func_echo_success_status, "$@ -> [ Done ]")
 
 
-### build-dashboard-centos : Build apache/dashboard:tag image on centos
-.PHONY: build-dashboard-centos
-build-dashboard-centos:
-	@$(call func_echo_status, "$@ -> [ Start ]")
-	$(ENV_DOCKER) build -t $(APISIX_DASHBOARD_IMAGE_NAME):$(APISIX_DASHBOARD_VERSION) -f ./dashboard/Dockerfile.centos .
-	@$(call func_echo_success_status, "$@ -> [ Done ]")
-
-
-### build-dashboard-alpine : Build apache/dashboard:tag image on alpine
-.PHONY: build-dashboard-alpine
-build-dashboard-alpine:
-	@$(call func_echo_status, "$@ -> [ Start ]")
-	$(ENV_DOCKER) build -t $(APISIX_DASHBOARD_IMAGE_NAME):$(APISIX_DASHBOARD_VERSION) -f ./dashboard/Dockerfile.alpine .
-	@$(call func_echo_success_status, "$@ -> [ Done ]")
-
-
 ### push-multiarch-dashboard : Build and push multiarch apache/dashboard:tag image
 .PHONY: push-multiarch-dashboard
 push-multiarch-dashboard:
 	@$(call func_echo_status, "$@ -> [ Start ]")
 	$(ENV_DOCKER) buildx build --push \
 		-t $(APISIX_DASHBOARD_IMAGE_NAME):$(APISIX_DASHBOARD_VERSION)-alpine \
-		--build-arg APISIX_DASHBOARD_VERSION=release/$(APISIX_DASHBOARD_VERSION) \
+		--build-arg APISIX_DASHBOARD_TAG=v$(APISIX_DASHBOARD_VERSION) \
 		--platform linux/amd64,linux/arm64 \
 		-f ./dashboard/Dockerfile.alpine .
 	$(ENV_DOCKER) buildx build --push \
 		-t $(APISIX_DASHBOARD_IMAGE_NAME):$(APISIX_DASHBOARD_VERSION)-centos \
-		--build-arg APISIX_DASHBOARD_VERSION=release/$(APISIX_DASHBOARD_VERSION) \
+		--build-arg APISIX_DASHBOARD_TAG=v$(APISIX_DASHBOARD_VERSION) \
 		--platform linux/amd64,linux/arm64 \
 		-f ./dashboard/Dockerfile.centos .
 	$(ENV_DOCKER) buildx build --push \
 		-t $(APISIX_DASHBOARD_IMAGE_NAME):latest \
-		--build-arg APISIX_DASHBOARD_VERSION=release/$(APISIX_DASHBOARD_VERSION) \
+		--build-arg APISIX_DASHBOARD_TAG=v$(APISIX_DASHBOARD_VERSION) \
 		--platform linux/amd64,linux/arm64 \
 		-f ./dashboard/Dockerfile.centos .
 	@$(call func_echo_success_status, "$@ -> [ Done ]")

--- a/all-in-one/apisix-dashboard/Dockerfile
+++ b/all-in-one/apisix-dashboard/Dockerfile
@@ -63,10 +63,10 @@ RUN wget https://github.com/etcd-io/etcd/releases/download/${ETCD_VERSION}/etcd-
 # Build APISIX Dashboard - 1. download source code from github
 FROM alpine:latest as pre-build
 
-ARG APISIX_DASHBOARD_VERSION
+ARG APISIX_DASHBOARD_TAG
 
 RUN set -x \
-    && wget https://github.com/apache/apisix-dashboard/archive/${APISIX_DASHBOARD_VERSION}.tar.gz -O /tmp/apisix-dashboard.tar.gz \
+    && wget https://github.com/apache/apisix-dashboard/archive/${APISIX_DASHBOARD_TAG}.tar.gz -O /tmp/apisix-dashboard.tar.gz \
     && mkdir /usr/local/apisix-dashboard \
     && tar -xvf /tmp/apisix-dashboard.tar.gz -C /usr/local/apisix-dashboard --strip 1
 

--- a/dashboard/Dockerfile.alpine
+++ b/dashboard/Dockerfile.alpine
@@ -18,11 +18,11 @@ ARG BUILDPLATFORM=amd64
 
 FROM --platform=$BUILDPLATFORM alpine:latest as pre-build
 
-ARG APISIX_DASHBOARD_VERSION=release/2.10
+ARG APISIX_DASHBOARD_TAG=v2.15.0
 
 RUN set -x \
     && apk add --no-cache --virtual .builddeps git \
-    && git clone https://github.com/apache/apisix-dashboard.git -b ${APISIX_DASHBOARD_VERSION} /usr/local/apisix-dashboard \
+    && git clone https://github.com/apache/apisix-dashboard.git -b ${APISIX_DASHBOARD_TAG} /usr/local/apisix-dashboard \
     && cd /usr/local/apisix-dashboard && git clean -Xdf \
     && rm -f ./.githash && git log --pretty=format:"%h" -1 > ./.githash
 

--- a/dashboard/Dockerfile.centos
+++ b/dashboard/Dockerfile.centos
@@ -18,11 +18,11 @@ ARG BUILDPLATFORM=amd64
 
 FROM --platform=$BUILDPLATFORM alpine:latest as pre-build
 
-ARG APISIX_DASHBOARD_VERSION=release/2.10
+ARG APISIX_DASHBOARD_TAG=v2.15.0
 
 RUN set -x \
     && apk add --no-cache --virtual .builddeps git \
-    && git clone https://github.com/apache/apisix-dashboard.git -b ${APISIX_DASHBOARD_VERSION} /usr/local/apisix-dashboard \
+    && git clone https://github.com/apache/apisix-dashboard.git -b ${APISIX_DASHBOARD_TAG} /usr/local/apisix-dashboard \
     && cd /usr/local/apisix-dashboard && git clean -Xdf \
     && rm -f ./.githash && git log --pretty=format:"%h" -1 > ./.githash
 

--- a/example/docker-compose-arm64.yml
+++ b/example/docker-compose-arm64.yml
@@ -19,7 +19,7 @@ version: "3"
 
 services:
   apisix-dashboard:
-    image: apache/apisix-dashboard:2.14.0-alpine
+    image: apache/apisix-dashboard:2.15.0-alpine
     restart: always
     volumes:
       - ./dashboard_conf/conf.yaml:/usr/local/apisix-dashboard/conf/conf.yaml

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -19,7 +19,7 @@ version: "3"
 
 services:
   apisix-dashboard:
-    image: apache/apisix-dashboard:2.14.0-alpine
+    image: apache/apisix-dashboard:2.15.0-alpine
     restart: always
     volumes:
     - ./dashboard_conf/conf.yaml:/usr/local/apisix-dashboard/conf/conf.yaml


### PR DESCRIPTION
### NOTE

A CI is in a failed state because the image is not pushed due to a branch not being created, and you can ignore it.