### PR TITLE
fix: add etcdctl binary when use_grpc

### DIFF
--- a/all-in-one/apisix/Dockerfile
+++ b/all-in-one/apisix/Dockerfile
@@ -16,21 +16,18 @@
 #
 
 ARG ENABLE_PROXY=false
-ARG ETCD_VERSION=v3.5.4
+ARG ETCD_VERSION=v3.5.6
+
+FROM quay.io/coreos/etcd:$ETCD_VERSION as etcddep
 
 # Build Apache APISIX
 FROM apache/apisix:latest
 
-
-ARG ETCD_VERSION
 LABEL etcd_version="${ETCD_VERSION}"
 
+COPY --from=etcddep /usr/local/bin/* /usr/local/bin/
+
 WORKDIR /tmp
-
-RUN wget https://github.com/etcd-io/etcd/releases/download/${ETCD_VERSION}/etcd-${ETCD_VERSION}-linux-amd64.tar.gz \
-    && tar -zxvf etcd-${ETCD_VERSION}-linux-amd64.tar.gz \
-    && mv etcd-${ETCD_VERSION}-linux-amd64/* /usr/bin/
-
 
 WORKDIR /usr/local/apisix
 

--- a/centos/Dockerfile
+++ b/centos/Dockerfile
@@ -15,6 +15,9 @@
 # limitations under the License.
 #
 
+ARG ETCD_VERSION=v3.5.6
+
+FROM quay.io/coreos/etcd:$ETCD_VERSION as etcddep
 FROM centos:7
 
 ARG APISIX_VERSION=3.1.0
@@ -33,6 +36,7 @@ RUN ln -sf /dev/stdout /usr/local/apisix/logs/access.log \
 
 EXPOSE 9080 9443
 
+COPY --from=etcddep /usr/local/bin/etcdctl /usr/local/bin/etcdctl
 COPY ./docker-entrypoint.sh /docker-entrypoint.sh
 
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/debian-dev/Dockerfile
+++ b/debian-dev/Dockerfile
@@ -15,6 +15,9 @@
 # limitations under the License.
 #
 
+ARG ETCD_VERSION=v3.5.6
+
+FROM quay.io/coreos/etcd:$ETCD_VERSION as etcddep
 FROM api7/apisix-base:dev AS build
 
 ARG ENABLE_PROXY=false
@@ -44,6 +47,7 @@ RUN set -x \
 
 FROM api7/apisix-base:dev AS production-stage
 
+COPY --from=etcddep /usr/local/bin/etcdctl /usr/local/bin/etcdctl
 COPY --from=build /usr/local/apisix /usr/local/apisix
 COPY --from=build /usr/bin/apisix /usr/bin/apisix
 

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -15,8 +15,11 @@
 # limitations under the License.
 #
 
-FROM debian:bullseye-slim
+ARG ETCD_VERSION=v3.5.6
 
+FROM quay.io/coreos/etcd:$ETCD_VERSION as etcddep
+
+FROM debian:bullseye-slim
 ARG APISIX_VERSION=3.1.0
 
 RUN set -ex; \
@@ -56,6 +59,7 @@ RUN ln -sf /dev/stdout /usr/local/apisix/logs/access.log \
 
 EXPOSE 9080 9443
 
+COPY --from=etcddep /usr/local/bin/etcdctl /usr/local/bin/etcdctl
 COPY ./docker-entrypoint.sh /docker-entrypoint.sh
 
 ENTRYPOINT ["/docker-entrypoint.sh"]


### PR DESCRIPTION
Signed-off-by: fengxsong <fengxsong@outlook.com>

When `etcd.use_grpc=true`, without `etcdctl` binary tool apisix will ~~crash infinite~~ report error.

In order to build multi-arch images, use multistage build.