### PR TITLE
fix: etcdctl missing due to PATH var is not set correctly

### DIFF
--- a/centos/Dockerfile
+++ b/centos/Dockerfile
@@ -27,6 +27,8 @@ RUN yum install -y https://repos.apiseven.com/packages/centos/apache-apisix-repo
 
 WORKDIR /usr/local/apisix
 
+ENV PATH=$PATH:/usr/local/openresty/luajit/bin:/usr/local/openresty/nginx/sbin:/usr/local/openresty/bin
+
 # forward request and error logs to docker log collector
 RUN ln -sf /dev/stdout /usr/local/apisix/logs/access.log \
     && ln -sf /dev/stderr /usr/local/apisix/logs/error.log

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -46,6 +46,8 @@ RUN set -ex; \
 
 WORKDIR /usr/local/apisix
 
+ENV PATH=$PATH:/usr/local/openresty/luajit/bin:/usr/local/openresty/nginx/sbin:/usr/local/openresty/bin
+
 RUN useradd -u 1001 apisix && chown -R apisix:apisix /usr/local/apisix
 
 USER apisix


### PR DESCRIPTION
Signed-off-by: fengxsong <fengxsong@outlook.com>

fix https://github.com/apache/apisix-docker/issues/400#issuecomment-1373327999_