### PR TITLE
fix: config files overwritten by docker-entrypoint.sh

### DIFF
--- a/centos/docker-entrypoint.sh
+++ b/centos/docker-entrypoint.sh
@@ -22,18 +22,22 @@ PREFIX=${APISIX_PREFIX:=/usr/local/apisix}
 
 if [[ "$1" == "docker-start" ]]; then
     if [ "$APISIX_STAND_ALONE" = "true" ]; then
-        cat > ${PREFIX}/conf/config.yaml << _EOC_
+        if [ ! -f ${PREFIX}/conf/config.yaml ]; then
+          cat > ${PREFIX}/conf/config.yaml << _EOC_
 deployment:
   role: data_plane
   role_data_plane:
     config_provider: yaml
 _EOC_
+        fi
 
-        cat > ${PREFIX}/conf/apisix.yaml << _EOC_
+        if [ ! -f ${PREFIX}/conf/apisix.yaml]; then
+          cat > ${PREFIX}/conf/apisix.yaml << _EOC_
 routes:
   -
 #END
 _EOC_
+        fi
         /usr/bin/apisix init
     else
         /usr/bin/apisix init

--- a/debian-dev/docker-entrypoint.sh
+++ b/debian-dev/docker-entrypoint.sh
@@ -22,18 +22,22 @@ PREFIX=${APISIX_PREFIX:=/usr/local/apisix}
 
 if [[ "$1" == "docker-start" ]]; then
     if [ "$APISIX_STAND_ALONE" = "true" ]; then
-        cat > ${PREFIX}/conf/config.yaml << _EOC_
+        if [ ! -f ${PREFIX}/conf/config.yaml ]; then
+          cat > ${PREFIX}/conf/config.yaml << _EOC_
 deployment:
   role: data_plane
   role_data_plane:
     config_provider: yaml
 _EOC_
+        fi
 
-        cat > ${PREFIX}/conf/apisix.yaml << _EOC_
+        if [ ! -f ${PREFIX}/conf/apisix.yaml]; then
+          cat > ${PREFIX}/conf/apisix.yaml << _EOC_
 routes:
   -
 #END
 _EOC_
+        fi
         /usr/bin/apisix init
     else
         /usr/bin/apisix init

--- a/debian/docker-entrypoint.sh
+++ b/debian/docker-entrypoint.sh
@@ -21,19 +21,23 @@ set -eo pipefail
 PREFIX=${APISIX_PREFIX:=/usr/local/apisix}
 
 if [[ "$1" == "docker-start" ]]; then
-    if [ "$APISIX_STAND_ALONE" = "true" ]; then
-        cat > ${PREFIX}/conf/config.yaml << _EOC_
+    if [ "$APISIX_STAND_ALONE" = "true"]; then
+        if [ ! -f ${PREFIX}/conf/config.yaml ]; then
+          cat > ${PREFIX}/conf/config.yaml << _EOC_
 deployment:
   role: data_plane
   role_data_plane:
     config_provider: yaml
 _EOC_
+        fi
 
+        if [ ! -f ${PREFIX}/conf/apisix.yaml]; then
         cat > ${PREFIX}/conf/apisix.yaml << _EOC_
 routes:
   -
 #END
 _EOC_
+        fi
         /usr/bin/apisix init
     else
         /usr/bin/apisix init


### PR DESCRIPTION
This pull request fixes #401 

The docker-entrypoint.sh will generate an apisix.yaml and config.yaml files without verifying if the user has provided / mounted them already.

This simple fix adds an extra IF condition that verifies if the files are not present before overwriting them.
 