### PR TITLE
fix: apisix config etcd indent error

### DIFF
--- a/example/apisix_conf/config.yaml
+++ b/example/apisix_conf/config.yaml
@@ -38,11 +38,11 @@ deployment:
         key: 4054f7cf07e344346cd3f287985e76a2
         role: viewer
 
-  etcd:
-    host:                           # it's possible to define multiple etcd hosts addresses of the same etcd cluster.
-      - "http://etcd:2379"          # multiple etcd address
-    prefix: "/apisix"               # apisix configurations prefix
-    timeout: 30                     # 30 seconds
+etcd:
+  host:                           # it's possible to define multiple etcd hosts addresses of the same etcd cluster.
+    - "http://etcd:2379"          # multiple etcd address
+  prefix: "/apisix"               # apisix configurations prefix
+  timeout: 30                     # 30 seconds
 
 plugin_attr:
   prometheus:


### PR DESCRIPTION
Due to apisix `config.yaml` indent error, etcd configuration didn't passthrought to apisix,  it would cause problem that apisix use default config to connect etcd by `127.0.0.1:2379`