### PR TITLE
chore: cleanup example documentation

### DIFF
--- a/docs/en/latest/example.md
+++ b/docs/en/latest/example.md
@@ -26,54 +26,54 @@ title: Example
 ### Run
 
 ```
-docker-compose -p docker-apisix up -d
+docker-compose -d
 ```
 
 ### Configure
 
 ```
-curl http://127.0.0.1:9080/apisix/admin/services/1 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
+curl http://127.0.0.1:9180/apisix/admin/services/1 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
 {
     "upstream": {
         "type": "roundrobin",
         "nodes": {
-            "172.18.5.12:80": 1
+            "web1:80": 1
         }
     }
 }'
 
-curl http://127.0.0.1:9080/apisix/admin/services/2 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
+curl http://127.0.0.1:9180/apisix/admin/services/2 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
 {
     "upstream": {
         "type": "roundrobin",
         "nodes": {
-            "172.18.5.13:80": 1
+            "web2:80": 1
         }
     }
 }'
 
-curl http://127.0.0.1:9080/apisix/admin/routes/12 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
+curl http://127.0.0.1:9180/apisix/admin/routes/12 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
 {
     "uri": "/*",
     "host": "web1.lvh.me",
     "service_id": "1"
 }'
 
-curl http://127.0.0.1:9080/apisix/admin/routes/22 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
+curl http://127.0.0.1:9180/apisix/admin/routes/22 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
 {
     "uri": "/*",
     "host": "web2.lvh.me",
     "service_id": "2"
 }'
 
-curl http://127.0.0.1:9080/apisix/admin/ssl/1 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d "
+curl http://127.0.0.1:9180/apisix/admin/ssl/1 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d "
 {
     \"cert\": \"$( cat './mkcert/lvh.me+1.pem')\",
     \"key\": \"$( cat './mkcert/lvh.me+1-key.pem')\",
     \"sni\": \"lvh.me\"
 }"
 
-curl http://127.0.0.1:9080/apisix/admin/ssl/2 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d "
+curl http://127.0.0.1:9180/apisix/admin/ssl/2 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d "
 {
     \"cert\": \"$( cat './mkcert/lvh.me+1.pem')\",
     \"key\": \"$( cat './mkcert/lvh.me+1-key.pem')\",
@@ -99,7 +99,7 @@ curl https://web1.lvh.me:9443/ -v --cacert ./mkcert/rootCA.pem
 ### Clean
 
 ```
-docker-compose -p docker-apisix down
+docker-compose down
 
 sudo rm -rf etcd_data/member
 


### PR DESCRIPTION
- Removed profile flag from docker-compose up/dow command as the compose files do not contain any profile
specific configuration (anymore).

- Changed port for all admin API calls from 9080 to 9180 because the admin api is not exposed on 9080.

- Replaced ip addresses inside service upstream config with compose service names. CIDR for the bridge created by docker-compose might differ between machines, hostnames are fixed.