### PR TITLE
fix: apisix all-in-one docker file

### DIFF
--- a/all-in-one/apisix/Dockerfile
+++ b/all-in-one/apisix/Dockerfile
@@ -29,7 +29,7 @@ WORKDIR /tmp
 
 USER root
 
-RUN wget https://github.com/etcd-io/etcd/releases/download/${ETCD_VERSION}/etcd-${ETCD_VERSION}-linux-amd64.tar.gz \
+RUN curl -sSL https://github.com/etcd-io/etcd/releases/download/${ETCD_VERSION}/etcd-${ETCD_VERSION}-linux-amd64.tar.gz -o etcd-${ETCD_VERSION}-linux-amd64.tar.gz \
     && tar -zxvf etcd-${ETCD_VERSION}-linux-amd64.tar.gz \
     && mv etcd-${ETCD_VERSION}-linux-amd64/* /usr/bin/
 


### PR DESCRIPTION
refer to https://github.com/apache/apisix-docker/pull/419
This change misses other files and causes errors.