### PR TITLE
chore: specify the example apisix tag 3.1.0-debian

### DIFF
--- a/example/docker-compose-arm64.yml
+++ b/example/docker-compose-arm64.yml
@@ -29,7 +29,7 @@ services:
       apisix:
 
   apisix:
-    image: apache/apisix:latest
+    image: apache/apisix:3.1.0-debian
     restart: always
     volumes:
       - ./apisix_log:/usr/local/apisix/logs

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       apisix:
 
   apisix:
-    image: apache/apisix:latest
+    image: apache/apisix:3.1.0-debian
     restart: always
     volumes:
       - ./apisix_log:/usr/local/apisix/logs


### PR DESCRIPTION
The latest tag should not be used.