### PR TITLE
fix: keep both curl and wget in apisix image

### DIFF
--- a/all-in-one/apisix/Dockerfile
+++ b/all-in-one/apisix/Dockerfile
@@ -29,7 +29,7 @@ WORKDIR /tmp
 
 USER root
 
-RUN curl -sSL https://github.com/etcd-io/etcd/releases/download/${ETCD_VERSION}/etcd-${ETCD_VERSION}-linux-amd64.tar.gz -o etcd-${ETCD_VERSION}-linux-amd64.tar.gz \
+RUN wget https://github.com/etcd-io/etcd/releases/download/${ETCD_VERSION}/etcd-${ETCD_VERSION}-linux-amd64.tar.gz \
     && tar -zxvf etcd-${ETCD_VERSION}-linux-amd64.tar.gz \
     && mv etcd-${ETCD_VERSION}-linux-amd64/* /usr/bin/
 

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -22,18 +22,18 @@ ARG APISIX_VERSION=3.1.0
 RUN set -ex; \
     arch=$(dpkg --print-architecture); \
     apt update; \
-    apt-get -y install --no-install-recommends gnupg ca-certificates curl; \
+    apt-get -y install --no-install-recommends wget gnupg ca-certificates curl; \
     codename=`grep -Po 'VERSION="[0-9]+ \(\K[^)]+' /etc/os-release`; \
-    curl -sSL https://openresty.org/package/pubkey.gpg | apt-key add -; \
+    wget -O - https://openresty.org/package/pubkey.gpg | apt-key add -; \
     case "${arch}" in \
       amd64) \
         echo "deb http://openresty.org/package/debian $codename openresty" | tee /etc/apt/sources.list.d/openresty.list \
-        && curl -sSL http://repos.apiseven.com/pubkey.gpg | apt-key add - \
+        && wget -O - http://repos.apiseven.com/pubkey.gpg | apt-key add - \
         && echo "deb http://repos.apiseven.com/packages/debian $codename main" | tee /etc/apt/sources.list.d/apisix.list \
         ;; \
       arm64) \
         echo "deb http://openresty.org/package/arm64/debian $codename openresty" | tee /etc/apt/sources.list.d/openresty.list \
-        && curl -sSL http://repos.apiseven.com/pubkey.gpg | apt-key add - \
+        && wget -O - http://repos.apiseven.com/pubkey.gpg | apt-key add - \
         && echo "deb http://repos.apiseven.com/packages/arm64/debian $codename main" | tee /etc/apt/sources.list.d/apisix.list \
         ;; \
     esac; \


### PR DESCRIPTION
To fix the problem with https://github.com/apache/apisix-ingress-controller/issues/1637 we decided to replace the `wget` in the apisix image with `curl` and made the change in
- https://github.com/apache/apisix-docker/pull/419
- https://github.com/apache/apisix-docker/pull/421

But we found that this caused problems for some users of build image base apisix: why did `wget` suddenly disappear?
Just like the changes in this PR https://github.com/apache/apisix-docker/pull/423

So we'd better keep both `wget` and `curl`.