### PR TITLE
chore: update go version

### DIFF
--- a/dashboard/Dockerfile.alpine
+++ b/dashboard/Dockerfile.alpine
@@ -26,7 +26,7 @@ RUN set -x \
     && cd /usr/local/apisix-dashboard && git clean -Xdf \
     && rm -f ./.githash && git log --pretty=format:"%h" -1 > ./.githash
 
-FROM --platform=$BUILDPLATFORM golang:1.17 as api-builder
+FROM --platform=$BUILDPLATFORM golang:1.19 as api-builder
 
 ARG ENABLE_PROXY=false
 

--- a/dashboard/Dockerfile.centos
+++ b/dashboard/Dockerfile.centos
@@ -26,7 +26,7 @@ RUN set -x \
     && cd /usr/local/apisix-dashboard && git clean -Xdf \
     && rm -f ./.githash && git log --pretty=format:"%h" -1 > ./.githash
 
-FROM --platform=$BUILDPLATFORM golang:1.17 as api-builder
+FROM --platform=$BUILDPLATFORM golang:1.19 as api-builder
 
 ARG ENABLE_PROXY=false
 


### PR DESCRIPTION
Use golang 1.19 in apisix-dashboard master branch.
https://github.com/apache/apisix-dashboard/blob/53cfc4cf35fbe5fe462b655f0e2b62f1f56195f8/api/go.mod#L3