### PR TITLE
chore: Image should be created with a non-root user

### DIFF
--- a/dashboard/Dockerfile.alpine
+++ b/dashboard/Dockerfile.alpine
@@ -59,6 +59,10 @@ FROM alpine:latest as prod
 
 WORKDIR /usr/local/apisix-dashboard
 
+RUN useradd -u 1001 apisix && chown -R apisix:apisix /usr/local/apisix-dashboard
+
+USER apisix
+
 COPY --from=api-builder /usr/local/apisix-dashboard/output/ ./
 
 COPY --from=fe-builder /usr/local/apisix-dashboard/output/ ./

--- a/dashboard/Dockerfile.centos
+++ b/dashboard/Dockerfile.centos
@@ -59,6 +59,10 @@ FROM centos:8 as prod
 
 WORKDIR /usr/local/apisix-dashboard
 
+RUN useradd -u 1001 apisix && chown -R apisix:apisix /usr/local/apisix-dashboard
+
+USER apisix
+
 COPY --from=api-builder /usr/local/apisix-dashboard/output/ ./
 
 COPY --from=fe-builder /usr/local/apisix-dashboard/output/ ./


### PR DESCRIPTION
For security reasons, the dashboard should also be consistent with APISIX.
* #411 