### PR TITLE
fix: etcd advertise_client_urls error

### DIFF
--- a/example/docker-compose-arm64.yml
+++ b/example/docker-compose-arm64.yml
@@ -54,7 +54,7 @@ services:
       ETCD_UNSUPPORTED_ARCH: "arm64"
       ETCD_ENABLE_V2: "true"
       ALLOW_NONE_AUTHENTICATION: "yes"
-      ETCD_ADVERTISE_CLIENT_URLS: "http://0.0.0.0:2379"
+      ETCD_ADVERTISE_CLIENT_URLS: "http://etcd:2379"
       ETCD_LISTEN_CLIENT_URLS: "http://0.0.0.0:2379"
       ETCD_DATA_DIR: "/etcd-data"
     ports:


### PR DESCRIPTION
修复 [docker-compose-arm64.yml](https://github.com/apache/apisix-docker/blob/master/example/docker-compose-arm64.yml) 中 ETCD_ADVERTISE_CLIENT_URLS 环境变量