### PR TITLE
Update apisix uid in the Debian Dockerfile

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -48,7 +48,7 @@ WORKDIR /usr/local/apisix
 
 ENV PATH=$PATH:/usr/local/openresty/luajit/bin:/usr/local/openresty/nginx/sbin:/usr/local/openresty/bin
 
-RUN useradd -u 6336 apisix && chown -R apisix:apisix /usr/local/apisix
+RUN useradd --system --no-create-home --home /nonexistent --shell /bin/false --uid 636 apisix && chown -R apisix:apisix /usr/local/apisix
 
 USER apisix
 

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -48,7 +48,7 @@ WORKDIR /usr/local/apisix
 
 ENV PATH=$PATH:/usr/local/openresty/luajit/bin:/usr/local/openresty/nginx/sbin:/usr/local/openresty/bin
 
-RUN useradd -u 1001 apisix && chown -R apisix:apisix /usr/local/apisix
+RUN useradd -u 6336 apisix && chown -R apisix:apisix /usr/local/apisix
 
 USER apisix
 

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -48,7 +48,9 @@ WORKDIR /usr/local/apisix
 
 ENV PATH=$PATH:/usr/local/openresty/luajit/bin:/usr/local/openresty/nginx/sbin:/usr/local/openresty/bin
 
-RUN useradd --system --no-create-home --home /nonexistent --shell /bin/false --uid 636 apisix && chown -R apisix:apisix /usr/local/apisix
+RUN groupadd --system --gid 636 apisix \
+    && useradd --system --gid apisix --no-create-home --shell /usr/sbin/nologin --uid 636 apisix \
+    && chown -R apisix:apisix /usr/local/apisix
 
 USER apisix
 


### PR DESCRIPTION
This PR updates `apisix` uid in the Debian Dockerfile to avoid conflicts.

The `uid` was initially introduced by https://github.com/apache/apisix-docker/issues/326

**Reason for the update**: to mount a file to the container built off this image for data persistency, users could encounter **Permission Denied** when container user is trying to write to the file on the host that's mounted. This could be resolved by changing the ownership of the mounted directory/file on host to `apisix` user with the same uid as in the container. The `apisix` user needs to be created on host.

For example:

```
sudo useradd -u 1001 apisix
mkdir ~/conf
touch ~/conf/config.yaml
sudo chown -R apisix:apisix ~/conf
```

However, it is quite common to have a pre-existing user with uid 1001. Hence this PR changes the uid.