### PR TITLE
docs: add info about building docker image

### DIFF
--- a/docs/en/latest/build.md
+++ b/docs/en/latest/build.md
@@ -38,3 +38,12 @@ make build-on-debian
 export APISIX_VERSION=master
 make build-on-debian
 ```
+
+### Build an image from customized/patched source code:
+
+1. `cd` into the root of APISIX project.
+2. Use the provided [dockerfile](../../../debian-dev/Dockerfile.local) to build an image like so:
+
+```shell
+docker build -t apisix-dev-local -f /path/to/debian-dev/Dockerfile.local  .
+```

--- a/docs/en/latest/build.md
+++ b/docs/en/latest/build.md
@@ -39,7 +39,7 @@ export APISIX_VERSION=master
 make build-on-debian
 ```
 
-### Build an image from customized/patched source code:
+### Build an image from customized/patched source code
 
 1. `cd` into the root of APISIX project.
 2. Use the provided [dockerfile](../../../debian-dev/Dockerfile.local) to build an image like so:


### PR DESCRIPTION
Document the way for building docker images from local source code.