### PR TITLE
feat: Quickly build a local development and debugging environment

### DIFF
--- a/debian-emmy/apisix/README.md
+++ b/debian-emmy/apisix/README.md
@@ -1,0 +1,6 @@
+> **Say important things three times:**
+>   - This is the source code directory for debugging, please place the source code in this directory !!!
+>   - This is the source code directory for debugging, please place the source code in this directory !!!
+>   - This is the source code directory for debugging, please place the source code in this directory !!!
+
+

--- a/debian-emmy/apisix_conf/config.yaml
+++ b/debian-emmy/apisix_conf/config.yaml
@@ -1,0 +1,50 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apisix:
+  node_listen: 9080              # APISIX listening port
+  enable_ipv6: false
+
+deployment:
+  admin:
+    allow_admin:               # https://nginx.org/en/docs/http/ngx_http_access_module.html#allow
+      - 0.0.0.0/0              # We need to restrict ip access rules for security. 0.0.0.0/0 is for test.
+
+    admin_key:
+      - name: "admin"
+        key: edd1c9f034335f136f87ad84b625c8f1
+        role: admin                 # admin: manage all configuration data
+
+  etcd:
+    host:                           # it's possible to define multiple etcd hosts addresses of the same etcd cluster.
+      - "http://etcd:2379"          # multiple etcd address
+    prefix: "/apisix"               # apisix configurations prefix
+    timeout: 30                     # 30 seconds
+
+# [Debian Emmy]: It is only recommended to start one worker in the debug environment.
+nginx_config:
+  worker_processes: 1
+# [Debian Emmy]: Loading emmy debugger.lua during the startup of Apisix is the key to emmy dbg listening and hooking(fix path).
+plugins:
+  - emmy-debugger                        # priority: 50000
+
+# [Debian Emmy]: The fixPath function retrieves the path of the file and "fixes" it to the path expected by VS Code.
+plugin_attr:
+  emmy-debugger:
+    # modify apisix
+    fix_path: ${prefix}/apisix-docker-debugger/debian-emmy/apisix
+    port: 9966

--- a/debian-emmy/docker-compose.yaml
+++ b/debian-emmy/docker-compose.yaml
@@ -1,0 +1,62 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+version: "3"
+networks:
+  apisix:
+    driver: bridge
+services:
+  apisix:
+    # [Debian Emmy]: This is a built emmy debug image that includes /usr/local/emmy.so. 
+    # [Debian Emmy]: If there is no special version available, you can use this version directly.
+    # [Debian Emmy]: If there is a need for customization.
+    # [Debian Emmy]: Build an image version based on the ./image/Dockerfile
+    # [Debian Emmy]: TAG: arm or amd
+    image: "coderjia/apisix-emmy:${TAG}"
+    restart: always
+    volumes:
+      - ./apisix_conf/config.yaml:/usr/local/apisix/conf/config.yaml:ro
+      # [Debian Emmy]: Customized version of Apisix source code
+      - ./apisix:/usr/local/apisix/apisix:ro
+      # [Debian Emmy]: When customizing code, you can volume it in more directories.
+
+    depends_on:
+      - etcd
+    ports:
+      - "9180:9180/tcp"
+      - "9080:9080/tcp"
+      - "9091:9091/tcp"
+      - "9443:9443/tcp"
+      # [Debian Emmy]: listen tcp port
+      - "9966:9966/tcp"
+    networks:
+      - apisix
+  etcd:
+    image: bitnami/etcd:3.4.9
+    user: root
+    restart: always
+    volumes:
+      - ../example/etcd_data:/etcd_data
+    environment:
+      ETCD_DATA_DIR: /etcd_data
+      ETCD_ENABLE_V2: "true"
+      ALLOW_NONE_AUTHENTICATION: "yes"
+      ETCD_ADVERTISE_CLIENT_URLS: "http://0.0.0.0:2379"
+      ETCD_LISTEN_CLIENT_URLS: "http://0.0.0.0:2379"
+    ports:
+      - "2379:2379/tcp"
+    networks:
+      - apisix

--- a/debian-emmy/docs/README-CN.md
+++ b/debian-emmy/docs/README-CN.md
@@ -1,0 +1,132 @@
+## 如何在容器化环境调试PISIX
+> 使用过程中有问题可以参考 [样例项目](https://github.com/cj2a7t/apisix-docker-debugger)
+### 1.为什么要在容器化环境调试？
+由于[Mac M1 make run error ](https://github.com/apache/apisix/issues/7313)、每个开发环境(windows、ubuntu、mac、mac m1等等)本地源码安装方式的差异、没有单步调试的直接方式等问题。我们想搭建一套可以单步调试的Apisix开发环境，需要查阅很多资料，而且资料特别分散。所以想在Apisix Dokcer仓库基于debian-dev提供一种快速的搭建本地开发环境的方式。下面以VS code为例来搭建一套Apisix的开发环境。
+### 2.开发环境全景图
+![image.png](https://p6-juejin.byteimg.com/tos-cn-i-k3u1fbpfcp/e1115731c7bd44b8ab800c96de5a6ed2~tplv-k3u1fbpfcp-jj-mark:0:0:0:0:q75.image#?w=2166&h=902&e=png&b=fefcfc)
+### 3.扩展构建步骤说明
+#### 3.1 构建镜像
+debian-emmy中的docker-compose.yaml中配置的镜像是已经构建好的镜像(可以直接使用)，如果有其他需求可以采用下面的步骤，本地重新构建apisix-emmy镜像，用于本地调试使用。
+```dockerfile
+services:
+  apisix:
+    # [Debian Emmy]: This is a built emmy debug image that includes /usr/local/emmy.so. 
+    # [Debian Emmy]: If there is no special version available, you can use this version directly.
+    # [Debian Emmy]: If there is a need for customization.
+    # [Debian Emmy]: Build an image version based on the ./image/Dockerfile
+    # [Debian Emmy]: TAG: arm or amd
+    image: "coderjia/apisix-emmy:${TAG}"
+```
+在Debian-Emmy文件夹image目录下的Dockerfile，相对于官方的debian-dev新增如下内容，主要目的是将`emmy_core.so`文件直接生成到容器内的/usr/local/emmy/目录下，如果后续想升级emmy的debug版本，可以自行调整。然后构建出新的镜像。
+![image.png](https://p1-juejin.byteimg.com/tos-cn-i-k3u1fbpfcp/28c1e09877af422bac9a22d8697711ae~tplv-k3u1fbpfcp-jj-mark:0:0:0:0:q75.image#?w=1712&h=1728&e=png&b=101216)
+#### 3.2 准备调试的源码
+将自己的定制化版本的apisix源码，放置到这个目录中，如果你需要官方版本的代码学习，那可以直接拉取官方的源码目录代码。切记：是源码目录，不包含构建文件的目录。
+![image.png](https://p6-juejin.byteimg.com/tos-cn-i-k3u1fbpfcp/86386ba88ef8455cb178f57d87a31dd4~tplv-k3u1fbpfcp-jj-mark:0:0:0:0:q75.image#?w=952&h=334&e=png&b=04080c)
+将`./emmy/emmy-debugger.lua`插件拷贝到./apisix/plugins目录下，这个就是全景图中绿色的插件，用于容器内加载emmy debug。
+#### 3.3 配置调整
+a. 调整./apisix_conf/config.yaml中的fix_path，调整为你本地的源码绝对路径目录。
+```yaml
+# [Debian Emmy]: It is only recommended to start one worker in the debug environment.
+nginx_config:
+  worker_processes: 1
+# [Debian Emmy]: Loading emmy debugger.lua during the startup of Apisix is the key to emmy dbg listening and hooking(fix path).
+plugins:
+  - emmy-debugger                        # priority: 50000
+# [Debian Emmy]: The fixPath function retrieves the path of the file and "fixes" it to the path expected by VS Code.
+plugin_attr:
+  emmy-debugger:
+    fix_path: ${prefix}/apisix
+    port: 9966
+```
+b. 如果有需要挂载新的目录，调整docker-compose.yaml中的挂载目录。
+```yaml
+    volumes:
+      - ./apisix_conf/config.yaml:/usr/local/apisix/conf/config.yaml:ro
+      # [Debian Emmy]: Customized version of Apisix source code
+      - ./apisix:/usr/local/apisix/apisix:ro
+      # [Debian Emmy]: When customizing code, you can volume it in more directories.
+```
+#### 3.4 启动debug环境
+a. 先启动Apisix相关的容器
+```docker
+# Version needs to be adjusted independently  arm or amd
+TAG=amd docker-compose up -d
+```
+![image.png](https://p9-juejin.byteimg.com/tos-cn-i-k3u1fbpfcp/bed6ce4af3cb4959bc9f8227924bd8e1~tplv-k3u1fbpfcp-jj-mark:0:0:0:0:q75.image#?w=1922&h=218&e=png&b=01050b)
+查看日志，看emmy dbg是否已经开启监听
+![image.png](https://p9-juejin.byteimg.com/tos-cn-i-k3u1fbpfcp/6b2033beef334e42b7487efad259af5b~tplv-k3u1fbpfcp-jj-mark:0:0:0:0:q75.image#?w=1532&h=486&e=png&b=01050c)
+b. 在VS Code中安装Emmy Lua插件
+![image.png](https://p3-juejin.byteimg.com/tos-cn-i-k3u1fbpfcp/92383875ad134b2ebb64b492b60656d1~tplv-k3u1fbpfcp-jj-mark:0:0:0:0:q75.image#?w=950&h=150&e=png&b=0e1217)
+c. 配置 EmmyLua插件
+![image.png](https://p6-juejin.byteimg.com/tos-cn-i-k3u1fbpfcp/d91eff32757740ccb81e53406cf4e01e~tplv-k3u1fbpfcp-jj-mark:0:0:0:0:q75.image#?w=1044&h=488&e=png&b=04080c)
+选择EmmyLua New Debugger
+![image.png](https://p1-juejin.byteimg.com/tos-cn-i-k3u1fbpfcp/4b9e771a07b54ef5bd3a9776a2307d75~tplv-k3u1fbpfcp-jj-mark:0:0:0:0:q75.image#?w=1214&h=654&e=png&b=15181e)
+添加一行preLaunchTask
+![image.png](https://p9-juejin.byteimg.com/tos-cn-i-k3u1fbpfcp/f9633a9c201644b5a29aa17bf3cfa0a0~tplv-k3u1fbpfcp-jj-mark:0:0:0:0:q75.image#?w=1914&h=766&e=png&b=13151a)
+在.vscode创建个tasks.json，主要是为了debug之前重启下容器，避免代码缓存导致debug没有到新增的代码，还有一种方式是 [关闭lua code cache](https://openresty-reference.readthedocs.io/en/latest/Directives/#lua_code_cache)。另外task的command是以unix的系统为例，在windows系统里，可以调整为powershell。
+```json
+// unix
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "restartAndDelay",
+            "type": "shell",
+            "command": "sh",
+            "args": [
+                "-c",
+                "docker restart ${apisix_container_name} && sleep 3"
+            ]
+        }
+    ]
+}
+// windows
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "restartAndDelay",
+            "type": "shell",
+            "command": "powershell",
+            "args": [
+                "-NoProfile",
+                "-ExecutionPolicy", "Bypass",
+                "-Command", "docker restart ${apisix_container_name}; Start-Sleep -Seconds 3"
+            ]
+        }
+    ]
+}
+```
+d. 开始debug验证，在init.lua的access阶段加个断点
+![image.png](https://p6-juejin.byteimg.com/tos-cn-i-k3u1fbpfcp/3fc6f3be29814e019d18a3f669b3f7d8~tplv-k3u1fbpfcp-jj-mark:0:0:0:0:q75.image#?w=2626&h=1558&e=png&b=121418)
+VS Code启动监听
+![image.png](https://p9-juejin.byteimg.com/tos-cn-i-k3u1fbpfcp/04233b16c34d4d8caf235370c70cface~tplv-k3u1fbpfcp-jj-mark:0:0:0:0:q75.image#?w=4090&h=382&e=png&b=191c21)
+创建个测试路由，并调用路由
+```sh
+# create a new route
+curl -X PUT \
+  http://localhost:9180/apisix/admin/routes/1 \
+  -H 'Content-Type: application/json' \
+  -H 'x-api-key: edd1c9f034335f136f87ad84b625c8f1' \
+  -d '{
+    "uri": "/get",
+    "plugins": {},
+    "upstream": {
+        "pass_host": "node",
+        "type": "roundrobin",
+        "nodes": {
+            "httpbin.org": 1
+        }
+    }
+}'
+# call route
+curl --location 'http://localhost:9080/get'
+```
+当调用路由后，可以看到已经debug成功
+![image.png](https://p1-juejin.byteimg.com/tos-cn-i-k3u1fbpfcp/5f526712d16c40068b189dda49feb910~tplv-k3u1fbpfcp-jj-mark:0:0:0:0:q75.image#?w=4476&h=1712&e=png&b=16191e)
+### 相关资料
+- https://github.com/EmmyLua/EmmyLuaDebugger
+- https://github.com/apache/apisix/issues/7313
+- https://github.com/openresty/lua-nginx-module/pull/2037
+- https://dev.to/omervk/debugging-lua-inside-openresty-inside-docker-with-intellij-idea-2h95
+- https://github.com/apache/apisix-docker

--- a/debian-emmy/docs/README.md
+++ b/debian-emmy/docs/README.md
@@ -1,0 +1,131 @@
+## How to Debug APISIX in a Containerized Environment
+> If there are any problems during the use process, please refer to the [sample project](https://github.com/cj2a7t/apisix-docker-debugger).
+### 1.Why Debug in a Containerized Environment?
+Due to issues such a[Mac M1 make run error ](https://github.com/apache/apisix/issues/7313) differences in local source code installation methods for various development environments (Windows, Ubuntu, macOS, Mac M1, etc.), and the lack of a straightforward way for step-by-step debugging, setting up a development environment for APISIX with debugging capabilities requires a lot of scattered information. To address this, a fast way to establish a local development environment for APISIX is provided in the APISIX Docker repository based on debian-dev. The following guide demonstrates setting up an APISIX development environment using VS Code.
+### 2.Development Environment Overview
+![image.png](https://p6-juejin.byteimg.com/tos-cn-i-k3u1fbpfcp/e1115731c7bd44b8ab800c96de5a6ed2~tplv-k3u1fbpfcp-jj-mark:0:0:0:0:q75.image#?w=2166&h=902&e=png&b=fefcfc)
+### 3.Steps to Build the Environment
+#### 3.1 Build the Docker Image
+In the docker-compose.yaml file in the debian-emmy folder, you can use the pre-built image directly. However, if you have specific requirements, you can follow the steps below to build a custom apisix-emmy image for local debugging.
+```dockerfile
+services:
+  apisix:
+    # [Debian Emmy]: This is a built emmy debug image that includes /usr/local/emmy.so. 
+    # [Debian Emmy]: If there is no special version available, you can use this version directly.
+    # [Debian Emmy]: If there is a need for customization.
+    # [Debian Emmy]: TAG: arm or amd
+    image: "coderjia/apisix-emmy:${TAG}"
+```
+In the Dockerfile under the image directory in the debian-emmy folder, add the following lines to generate the emmy_core.so file directly into the /usr/local/emmy/ directory within the container. This is useful if you want to upgrade the debug version of Emmy later. Then build the new image.
+![image.png](https://p1-juejin.byteimg.com/tos-cn-i-k3u1fbpfcp/28c1e09877af422bac9a22d8697711ae~tplv-k3u1fbpfcp-jj-mark:0:0:0:0:q75.image#?w=1712&h=1728&e=png&b=101216)
+#### 3.2 Prepare Debuggable Source Code
+Place your customized version of the APISIX source code into this directory. If you wish to use the official codebase for learning purposes, you can directly clone the official repository. Remember that this should be the source code directory, excluding the build files.
+![image.png](https://p6-juejin.byteimg.com/tos-cn-i-k3u1fbpfcp/86386ba88ef8455cb178f57d87a31dd4~tplv-k3u1fbpfcp-jj-mark:0:0:0:0:q75.image#?w=952&h=334&e=png&b=04080c)
+Copy the`./emmy/emmy-debugger.lua`plugin to the `./apisix/plugins` directory. This plugin is responsible for loading the Emmy debugger within the container.
+#### 3.3 Adjust Configuration
+a.Modify the `./apisix_conf/config.yaml`in`fix_path`，to the absolute path of your local source code directory.
+```yaml
+# [Debian Emmy]: It is only recommended to start one worker in the debug environment.
+nginx_config:
+  worker_processes: 1
+# [Debian Emmy]: Loading emmy debugger.lua during the startup of Apisix is the key to emmy dbg listening and hooking(fix path).
+plugins:
+  - emmy-debugger                        # priority: 50000
+# [Debian Emmy]: The fixPath function retrieves the path of the file and "fixes" it to the path expected by VS Code.
+plugin_attr:
+  emmy-debugger:
+    fix_path: ${prefix}/apisix
+    port: 9966
+```
+b. If you need to mount additional directories, adjust the mount paths in the docker-compose.yaml file.
+```yaml
+    volumes:
+      - ./apisix_conf/config.yaml:/usr/local/apisix/conf/config.yaml:ro
+      # [Debian Emmy]: Customized version of Apisix source code
+      - ./apisix:/usr/local/apisix/apisix:ro
+      # [Debian Emmy]: When customizing code, you can volume it in more directories.
+```
+#### 3.4 Start the Debug Environment
+a. Start the APISIX-related containers.
+```docker
+# Version needs to be adjusted independently  arm or amd
+TAG=amd docker-compose up -d
+```
+![image.png](https://p9-juejin.byteimg.com/tos-cn-i-k3u1fbpfcp/bed6ce4af3cb4959bc9f8227924bd8e1~tplv-k3u1fbpfcp-jj-mark:0:0:0:0:q75.image#?w=1922&h=218&e=png&b=01050b)
+Check the logs to ensure that the Emmy debugger is listening.
+![image.png](https://p9-juejin.byteimg.com/tos-cn-i-k3u1fbpfcp/6b2033beef334e42b7487efad259af5b~tplv-k3u1fbpfcp-jj-mark:0:0:0:0:q75.image#?w=1532&h=486&e=png&b=01050c)
+b. Install the Emmy Lua plugin in VS Code.
+![image.png](https://p3-juejin.byteimg.com/tos-cn-i-k3u1fbpfcp/92383875ad134b2ebb64b492b60656d1~tplv-k3u1fbpfcp-jj-mark:0:0:0:0:q75.image#?w=950&h=150&e=png&b=0e1217)
+c. Configure the EmmyLua plugin.
+![image.png](https://p6-juejin.byteimg.com/tos-cn-i-k3u1fbpfcp/d91eff32757740ccb81e53406cf4e01e~tplv-k3u1fbpfcp-jj-mark:0:0:0:0:q75.image#?w=1044&h=488&e=png&b=04080c)
+Select the EmmyLua New Debugger.
+![image.png](https://p1-juejin.byteimg.com/tos-cn-i-k3u1fbpfcp/4b9e771a07b54ef5bd3a9776a2307d75~tplv-k3u1fbpfcp-jj-mark:0:0:0:0:q75.image#?w=1214&h=654&e=png&b=15181e)
+Add a preLaunchTask line.
+![image.png](https://p9-juejin.byteimg.com/tos-cn-i-k3u1fbpfcp/f9633a9c201644b5a29aa17bf3cfa0a0~tplv-k3u1fbpfcp-jj-mark:0:0:0:0:q75.image#?w=1914&h=766&e=png&b=13151a)
+Create a tasks.json in the .vscode directory. This is primarily done to restart the container before debugging, preventing code caching from causing the debugger to miss newly added code. Another approach is to [disable Lua code cache](https://openresty-reference.readthedocs.io/en/latest/Directives/#lua_code_cache). Additionally, note that the command in the task is an example for Unix-like systems, and on Windows systems, it can be adjusted to PowerShell.
+```json
+// unix
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "restartAndDelay",
+            "type": "shell",
+            "command": "sh",
+            "args": [
+                "-c",
+                "docker restart ${apisix_container_name} && sleep 3"
+            ]
+        }
+    ]
+}
+// windows
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "restartAndDelay",
+            "type": "shell",
+            "command": "powershell",
+            "args": [
+                "-NoProfile",
+                "-ExecutionPolicy", "Bypass",
+                "-Command", "docker restart ${apisix_container_name}; Start-Sleep -Seconds 3"
+            ]
+        }
+    ]
+}
+```
+d. Start debugging by adding breakpoints in the source code. Use the VS Code debugger to initiate the debugging process.
+![image.png](https://p6-juejin.byteimg.com/tos-cn-i-k3u1fbpfcp/3fc6f3be29814e019d18a3f669b3f7d8~tplv-k3u1fbpfcp-jj-mark:0:0:0:0:q75.image#?w=2626&h=1558&e=png&b=121418)
+Start listening in VS Code.
+![image.png](https://p9-juejin.byteimg.com/tos-cn-i-k3u1fbpfcp/04233b16c34d4d8caf235370c70cface~tplv-k3u1fbpfcp-jj-mark:0:0:0:0:q75.image#?w=4090&h=382&e=png&b=191c21)
+Create a test route and invoke the route.
+```sh
+# create a new route
+curl -X PUT \
+  http://localhost:9180/apisix/admin/routes/1 \
+  -H 'Content-Type: application/json' \
+  -H 'x-api-key: edd1c9f034335f136f87ad84b625c8f1' \
+  -d '{
+    "uri": "/get",
+    "plugins": {},
+    "upstream": {
+        "pass_host": "node",
+        "type": "roundrobin",
+        "nodes": {
+            "httpbin.org": 1
+        }
+    }
+}'
+# call route
+curl --location 'http://localhost:9080/get'
+```
+After invoking the route, you will observe a successful debugging session.
+![image.png](https://p1-juejin.byteimg.com/tos-cn-i-k3u1fbpfcp/5f526712d16c40068b189dda49feb910~tplv-k3u1fbpfcp-jj-mark:0:0:0:0:q75.image#?w=4476&h=1712&e=png&b=16191e)
+### References
+- https://github.com/EmmyLua/EmmyLuaDebugger
+- https://github.com/apache/apisix/issues/7313
+- https://github.com/openresty/lua-nginx-module/pull/2037
+- https://dev.to/omervk/debugging-lua-inside-openresty-inside-docker-with-intellij-idea-2h95
+- https://github.com/apache/apisix-docker

--- a/debian-emmy/emmy/emmy-debugger.lua
+++ b/debian-emmy/emmy/emmy-debugger.lua
@@ -1,0 +1,40 @@
+local require = require
+local core = require("apisix.core")
+local plugin = require("apisix.plugin")
+local ngx = ngx
+local ngx_worker_id = ngx.worker.id
+local log = core.log
+
+local plugin_name = "emmy-debugger"
+local _M = {
+    version = 1,
+    priority = 50000,
+    name = plugin_name,
+    schema = {}
+}
+
+local plugin_attr = plugin.plugin_attr(plugin_name)
+if not plugin_attr then
+    log.error("Get plugin attr failed, skip dpg listen...")
+    return _M
+end
+
+-- Code path differences inside and outside the associated Docker container
+-- @see https://github.com/EmmyLua/EmmyLuaDebugger/blob/3f8853897fe001250e6e8a80ace5b603b1caccd8/emmy_core/emmy_debugger.cpp#L428
+_G.emmy = {
+    fixPath = function(path)
+        return string.gsub(path, '/usr/local/apisix/apisix', plugin_attr['fix_path'])
+    end
+}
+
+-- Load emmy and start listening.
+package.cpath = package.cpath .. ";/usr/local/emmy/emmy_core.so"
+local dbg = require("emmy_core")
+local emmy_debug_port = plugin_attr['port'] or 9966
+-- Nginx is a multi process model, it avoids repeatedly binding ports and only starts one worker.
+if dbg and ngx_worker_id() == 0 then
+    dbg.tcpListen("localhost", emmy_debug_port)
+    log.warn("emmy-debugger dbg started: ", ngx_worker_id())
+end
+
+return _M

--- a/debian-emmy/image/Dockerfile
+++ b/debian-emmy/image/Dockerfile
@@ -1,0 +1,85 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+FROM api7/apisix-base:dev AS build
+
+ARG ENABLE_PROXY=true
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN set -x \
+    && (test "${ENABLE_PROXY}" != "true" || /bin/sed -i 's,http://deb.debian.org,http://ftp.cn.debian.org,g' /etc/apt/sources.list) \
+    # apt-get install os cmd deps
+    && apt-get -y update --fix-missing \
+    && apt-get install -y curl \
+        gawk \
+        git \
+        libldap2-dev \
+        liblua5.1-0-dev \
+        lua5.1 \
+        make \
+        sudo \
+        unzip \
+        wget \
+        # [Debian Emmy]
+        cmake \
+        g++ \
+    # source code and deps
+    && curl https://raw.githubusercontent.com/apache/apisix/master/utils/linux-install-luarocks.sh -sL | bash - \
+    && luarocks install https://github.com/apache/apisix/raw/master/rockspec/apisix-master-0.rockspec --tree=/usr/local/apisix/deps PCRE_DIR=/usr/local/openresty/pcre \
+    && cp -v /usr/local/apisix/deps/lib/luarocks/rocks-5.1/apisix/master-0/bin/apisix /usr/bin/ \
+    && mv /usr/local/apisix/deps/share/lua/5.1/apisix /usr/local/apisix \
+    # forward request and error logs to docker log collector
+    && ln -sf /dev/stdout /usr/local/apisix/logs/access.log \
+    && ln -sf /dev/stderr /usr/local/apisix/logs/error.log
+
+# [Debian Emmy]: build emmy_core.so
+WORKDIR /usr/local
+RUN set -x \
+    && mkdir emmy \
+    && wget -O emmy.tar.gz https://github.com/EmmyLua/EmmyLuaDebugger/archive/refs/tags/1.6.3.tar.gz \
+    && tar -zxvf emmy.tar.gz \
+    && rm emmy.tar.gz
+WORKDIR /usr/local/EmmyLuaDebugger-1.6.3
+RUN set -x \
+    && cmake -DCMAKE_CXX_COMPILER=g++ . \
+    && cmake --build . \
+    && cp ./emmy_core/emmy_core.so /usr/local/emmy/
+
+
+FROM api7/apisix-base:dev AS production-stage
+
+COPY --from=build /usr/local/apisix /usr/local/apisix
+COPY --from=build /usr/bin/apisix /usr/bin/apisix
+COPY --from=build /usr/local/emmy /usr/local/emmy
+
+ENV DEBIAN_FRONTEND noninteractive
+
+WORKDIR /usr/local/apisix
+
+ENV PATH=$PATH:/usr/local/openresty-debug/luajit/bin:/usr/local/openresty-debug/nginx/sbin:/usr/local/openresty-debug/bin
+
+EXPOSE 9080 9443
+
+COPY ./docker-entrypoint.sh /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
+CMD ["docker-start"]
+
+
+STOPSIGNAL SIGQUIT

--- a/debian-emmy/image/docker-entrypoint.sh
+++ b/debian-emmy/image/docker-entrypoint.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -eo pipefail
+
+PREFIX=${APISIX_PREFIX:=/usr/local/apisix}
+
+if [[ "$1" == "docker-start" ]]; then
+    if [ "$APISIX_STAND_ALONE" = "true" ]; then
+        cat > ${PREFIX}/conf/config.yaml << _EOC_
+deployment:
+  role: data_plane
+  role_data_plane:
+    config_provider: yaml
+_EOC_
+
+        cat > ${PREFIX}/conf/apisix.yaml << _EOC_
+routes:
+  -
+#END
+_EOC_
+        /usr/bin/apisix init
+    else
+        /usr/bin/apisix init
+        /usr/bin/apisix init_etcd
+    fi
+    
+    exec /usr/local/openresty-debug/bin/openresty -p /usr/local/apisix -g 'daemon off;'
+fi
+
+exec "$@"


### PR DESCRIPTION
A fast way to establish a local development environment for APISIX is provided in the APISIX Docker repository based on debian-dev. The following guide demonstrates setting up an APISIX development environment using VS Code.