### PR TITLE
fix: re-add the apisix.yaml in entrypoint script

### DIFF
--- a/centos/docker-entrypoint.sh
+++ b/centos/docker-entrypoint.sh
@@ -23,15 +23,19 @@ PREFIX=${APISIX_PREFIX:=/usr/local/apisix}
 if [[ "$1" == "docker-start" ]]; then
     if [ "$APISIX_STAND_ALONE" = "true" ]; then
       # If the file is not present then initialise the content otherwise update relevant keys for standalone mode
+      if [ ! -f "${PREFIX}/conf/apisix.yaml" ]; then
+        cat > ${PREFIX}/conf/apisix.yaml << _EOC_
+routes:
+  -
+#END
+_EOC_
+      fi
       if [ ! -f "${PREFIX}/conf/config.yaml" ]; then
           cat > ${PREFIX}/conf/config.yaml << _EOC_
 deployment:
   role: data_plane
   role_data_plane:
     config_provider: yaml
-routes:
-  -
-#END
 _EOC_
       else
           wget -qO /usr/local/apisix/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 \

--- a/debian-dev/docker-entrypoint.sh
+++ b/debian-dev/docker-entrypoint.sh
@@ -23,15 +23,19 @@ PREFIX=${APISIX_PREFIX:=/usr/local/apisix}
 if [[ "$1" == "docker-start" ]]; then
     if [ "$APISIX_STAND_ALONE" = "true" ]; then
       # If the file is not present then initialise the content otherwise update relevant keys for standalone mode
+      if [ ! -f "${PREFIX}/conf/apisix.yaml" ]; then
+        cat > ${PREFIX}/conf/apisix.yaml << _EOC_
+routes:
+  -
+#END
+_EOC_
+      fi
       if [ ! -f "${PREFIX}/conf/config.yaml" ]; then
           cat > ${PREFIX}/conf/config.yaml << _EOC_
 deployment:
   role: data_plane
   role_data_plane:
     config_provider: yaml
-routes:
-  -
-#END
 _EOC_
       else
           wget -qO /usr/local/apisix/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 \

--- a/debian/docker-entrypoint.sh
+++ b/debian/docker-entrypoint.sh
@@ -23,15 +23,19 @@ PREFIX=${APISIX_PREFIX:=/usr/local/apisix}
 if [[ "$1" == "docker-start" ]]; then
     if [ "$APISIX_STAND_ALONE" = "true" ]; then
       # If the file is not present then initialise the content otherwise update relevant keys for standalone mode
+      if [ ! -f "${PREFIX}/conf/apisix.yaml" ]; then
+        cat > ${PREFIX}/conf/apisix.yaml << _EOC_
+routes:
+  -
+#END
+_EOC_
+      fi
       if [ ! -f "${PREFIX}/conf/config.yaml" ]; then
           cat > ${PREFIX}/conf/config.yaml << _EOC_
 deployment:
   role: data_plane
   role_data_plane:
     config_provider: yaml
-routes:
-  -
-#END
 _EOC_
       else
           wget -qO /usr/local/apisix/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 \

--- a/redhat/docker-entrypoint.sh
+++ b/redhat/docker-entrypoint.sh
@@ -23,15 +23,19 @@ PREFIX=${APISIX_PREFIX:=/usr/local/apisix}
 if [[ "$1" == "docker-start" ]]; then
     if [ "$APISIX_STAND_ALONE" = "true" ]; then
       # If the file is not present then initialise the content otherwise update relevant keys for standalone mode
+      if [ ! -f "${PREFIX}/conf/apisix.yaml" ]; then
+        cat > ${PREFIX}/conf/apisix.yaml << _EOC_
+routes:
+  -
+#END
+_EOC_
+      fi
       if [ ! -f "${PREFIX}/conf/config.yaml" ]; then
           cat > ${PREFIX}/conf/config.yaml << _EOC_
 deployment:
   role: data_plane
   role_data_plane:
     config_provider: yaml
-routes:
-  -
-#END
 _EOC_
       else
           wget -qO /usr/local/apisix/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 \


### PR DESCRIPTION
apisix.yaml was mistakenly merged into config.yaml and the current docker-entrypoint.sh does not initialise apisix.yaml with empty routes when the file is not present for standalone mode. 