### PR TITLE
fix(ci): docker image scanning

### DIFF
--- a/.github/workflows/apisix_dev_push_docker_hub.yaml
+++ b/.github/workflows/apisix_dev_push_docker_hub.yaml
@@ -70,5 +70,5 @@ jobs:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: 'apache/apisix:${{ APISIX_DOCKER_TAG }}'
+          image-ref: 'apache/apisix:${{ env.APISIX_DOCKER_TAG }}'
           severity: 'CRITICAL,HIGH'

--- a/.github/workflows/apisix_dev_push_docker_hub.yaml
+++ b/.github/workflows/apisix_dev_push_docker_hub.yaml
@@ -72,3 +72,4 @@ jobs:
         with:
           image-ref: 'apache/apisix:${{ env.APISIX_DOCKER_TAG }}'
           severity: 'CRITICAL,HIGH'
+          exit-code: 1


### PR DESCRIPTION
The previous PR: #506, is missing one of the commits that I used to test it in my local fork. And the CI is failing: https://github.com/apache/apisix-docker/actions/runs/6323701339 because of the bug that exists due to the missing commit.

In the following line the environment variable has not been referenced correctly:

https://github.com/apache/apisix-docker/blob/c129ef542c7dabfae1f063bbe3dca7068ec37f64/.github/workflows/apisix_dev_push_docker_hub.yaml#L73

This has been fixed and I have added another commit that ensures the build fails when vulnerabilities exist.