### PR TITLE
chore: upgrade base image

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 ARG APISIX_VERSION=3.5.0
 


### PR DESCRIPTION
The existing image has a vulnerability: https://hub.docker.com/layers/library/debian/bullseye-slim/images/sha256-bb9ee60a865c4276e72b33b04c7892d4011e730d1e865d931537082e895bc385?context=repo&tab=vulnerabilities