### PR TITLE
chore: remove unnecessary dependencies

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -45,7 +45,7 @@ RUN set -ex; \
     && openresty -V \
     && apisix version
 
-RUN apt-get -y purge --auto-remove curl wget gnupg ca-certificates bash
+RUN apt-get -y purge --auto-remove curl wget gnupg ca-certificates bash 
 
 WORKDIR /usr/local/apisix
 

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -45,6 +45,8 @@ RUN set -ex; \
     && openresty -V \
     && apisix version
 
+RUN apt-get -y purge --auto-remove curl wget gnupg ca-certificates bash
+
 WORKDIR /usr/local/apisix
 
 ENV PATH=$PATH:/usr/local/openresty/luajit/bin:/usr/local/openresty/nginx/sbin:/usr/local/openresty/bin

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -45,7 +45,7 @@ RUN set -ex; \
     && openresty -V \
     && apisix version
 
-RUN apt-get -y purge --auto-remove curl wget gnupg ca-certificates bash --allow-remove-essential
+RUN apt-get -y purge --auto-remove curl wget gnupg ca-certificates --allow-remove-essential
 
 WORKDIR /usr/local/apisix
 

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -45,7 +45,7 @@ RUN set -ex; \
     && openresty -V \
     && apisix version
 
-RUN apt-get -y purge --auto-remove curl wget gnupg ca-certificates bash 
+RUN apt-get -y purge --auto-remove curl wget gnupg ca-certificates bash --allow-remove-essential
 
 WORKDIR /usr/local/apisix
 

--- a/debian/docker-entrypoint.sh
+++ b/debian/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/debian/docker-entrypoint.sh
+++ b/debian/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with


### PR DESCRIPTION
This removes unnecessary burden from the image and reduces the chances of having CVEs.