### PR TITLE
chore: remove docker image scanning

### DIFF
--- a/.github/workflows/apisix_dev_push_docker_hub.yaml
+++ b/.github/workflows/apisix_dev_push_docker_hub.yaml
@@ -66,10 +66,3 @@ jobs:
       - name: Push apisix image to Docker Hub
         run: |
           make push-multiarch-dev-on-debian
-
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: 'apache/apisix:${{ env.APISIX_DOCKER_TAG }}'
-          severity: 'CRITICAL,HIGH'
-          exit-code: 1


### PR DESCRIPTION
Following is the dependency graph for APISIX:

![image](https://github.com/apache/apisix-docker/assets/61597896/21d6cb71-cf68-4c30-a227-ea73cad8425a)

Most CVEs are from 3rd and 4th-level dependencies, which are difficult to upgrade/fix. Due to the existing CVEs the CI always fails and adding unfixable CVEs to an `allowlist` does not scale. Moreover, it is a problem in the long run for maintainers.

That's why I propose that we remove the docker image scanning workflow.