### PR TITLE
fix: save ca-certificates package

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -45,7 +45,7 @@ RUN set -ex; \
     && openresty -V \
     && apisix version
 
-RUN apt-get -y purge --auto-remove curl wget gnupg ca-certificates --allow-remove-essential
+RUN apt-get -y purge --auto-remove curl wget gnupg --allow-remove-essential
 
 WORKDIR /usr/local/apisix
 


### PR DESCRIPTION
## Description
Fixes https://github.com/apache/apisix/issues/10593

During the container making process, the `ca-certificates` package was uninstalled, resulting in a non-existent /etc/ssl folder.
The current PR job is to keep the `ca-certificates` package.