### PR TITLE
fix: update ETCD_ADVERTISE_CLIENT_URLS from 0.0.0.0 to FQDN

### DIFF
--- a/compose/docker-compose-master.yaml
+++ b/compose/docker-compose-master.yaml
@@ -43,7 +43,7 @@ services:
       ETCD_DATA_DIR: /etcd_data
       ETCD_ENABLE_V2: "true"
       ALLOW_NONE_AUTHENTICATION: "yes"
-      ETCD_ADVERTISE_CLIENT_URLS: "http://0.0.0.0:2379"
+      ETCD_ADVERTISE_CLIENT_URLS: "http://etcd:2379"
       ETCD_LISTEN_CLIENT_URLS: "http://0.0.0.0:2379"
     ports:
       - "2379:2379/tcp"

--- a/compose/docker-compose-release.yaml
+++ b/compose/docker-compose-release.yaml
@@ -43,7 +43,7 @@ services:
       ETCD_DATA_DIR: /etcd_data
       ETCD_ENABLE_V2: "true"
       ALLOW_NONE_AUTHENTICATION: "yes"
-      ETCD_ADVERTISE_CLIENT_URLS: "http://0.0.0.0:2379"
+      ETCD_ADVERTISE_CLIENT_URLS: "http://etcd:2379"
       ETCD_LISTEN_CLIENT_URLS: "http://0.0.0.0:2379"
     ports:
       - "2379:2379/tcp"


### PR DESCRIPTION
ETCD_ADVERTISE_CLIENT_URLS should not be 0.0.0.0.

Related issue: https://github.com/apache/apisix-docker/issues/454

The same issue was also reported by @bzp2010 to me for api7 docs.