### PR TITLE
fix: sed not suitable for docker if config.yaml is volume mounted #529

### DIFF
--- a/debian-dev/docker-entrypoint.sh
+++ b/debian-dev/docker-entrypoint.sh
@@ -32,9 +32,10 @@ deployment:
 _EOC_
       else
           # updating config.yaml for standalone mode
-          sed -i 's/role: traditional/role: data_plane/' ${PREFIX}/conf/config.yaml
-          sed -i 's/role_traditional:/role_data_plane:/' ${PREFIX}/conf/config.yaml
-          sed -i 's/config_provider: etcd/config_provider: yaml/' ${PREFIX}/conf/config.yaml
+          echo "$(sed 's/role: traditional/role: data_plane/g' ${PREFIX}/conf/config.yaml)" > ${PREFIX}/conf/config.yaml
+          echo "$(sed 's/role_traditional:/role_data_plane:/g' ${PREFIX}/conf/config.yaml)" > ${PREFIX}/conf/config.yaml
+          echo "$(sed 's/config_provider: etcd/config_provider: yaml/g' ${PREFIX}/conf/config.yaml)" > ${PREFIX}/conf/config.yaml
+
       fi
 
         if [ ! -f "${PREFIX}/conf/apisix.yaml" ]; then

--- a/debian/docker-entrypoint.sh
+++ b/debian/docker-entrypoint.sh
@@ -32,9 +32,9 @@ deployment:
 _EOC_
       else
           # updating config.yaml for standalone mode
-          sed -i 's/role: traditional/role: data_plane/' ${PREFIX}/conf/config.yaml
-          sed -i 's/role_traditional:/role_data_plane:/' ${PREFIX}/conf/config.yaml
-          sed -i 's/config_provider: etcd/config_provider: yaml/' ${PREFIX}/conf/config.yaml
+          echo "$(sed 's/role: traditional/role: data_plane/g' ${PREFIX}/conf/config.yaml)" > ${PREFIX}/conf/config.yaml
+          echo "$(sed 's/role_traditional:/role_data_plane:/g' ${PREFIX}/conf/config.yaml)" > ${PREFIX}/conf/config.yaml
+          echo "$(sed 's/config_provider: etcd/config_provider: yaml/g' ${PREFIX}/conf/config.yaml)" > ${PREFIX}/conf/config.yaml
       fi
 
         if [ ! -f "${PREFIX}/conf/apisix.yaml" ]; then

--- a/redhat/docker-entrypoint.sh
+++ b/redhat/docker-entrypoint.sh
@@ -32,9 +32,9 @@ deployment:
 _EOC_
       else
           # updating config.yaml for standalone mode
-          sed -i 's/role: traditional/role: data_plane/' ${PREFIX}/conf/config.yaml
-          sed -i 's/role_traditional:/role_data_plane:/' ${PREFIX}/conf/config.yaml
-          sed -i 's/config_provider: etcd/config_provider: yaml/' ${PREFIX}/conf/config.yaml
+          echo "$(sed 's/role: traditional/role: data_plane/g' ${PREFIX}/conf/config.yaml)" > ${PREFIX}/conf/config.yaml
+          echo "$(sed 's/role_traditional:/role_data_plane:/g' ${PREFIX}/conf/config.yaml)" > ${PREFIX}/conf/config.yaml
+          echo "$(sed 's/config_provider: etcd/config_provider: yaml/g' ${PREFIX}/conf/config.yaml)" > ${PREFIX}/conf/config.yaml
       fi
 
         if [ ! -f "${PREFIX}/conf/apisix.yaml" ]; then


### PR DESCRIPTION
### Description

fix: config.yaml couldn't be volume mounted when using standalone Deployment modes (https://github.com/apache/apisix-docker/issues/529)