### PR TITLE
fix: apisix-debian-dev image failed to run

### DIFF
--- a/.github/workflows/apisix_dev_docker_local_test.yaml
+++ b/.github/workflows/apisix_dev_docker_local_test.yaml
@@ -14,7 +14,8 @@ on:
       - 'release/apisix-2.15.**'
 
 env:
-  APISIX_IMAGE_TAG: "local"
+  APISIX_IMAGE_TAG: "local-debian-dev"
+  APISIX_VERSION: "local"
 
 jobs:
 
@@ -35,9 +36,10 @@ jobs:
           git clone https://github.com/apache/apisix.git
 
       - name: Build image
+        env:
+          LOCAL_CODE_PATH: ./apisix
         run: |
-          tag="apache/apisix:$APISIX_IMAGE_TAG"
-          docker build -t $tag -f debian-dev/Dockerfile.local  .
+          make build-on-debian-local-dev
 
       - name: use docker-compose
         run: docker-compose -p docker-apisix -f example/docker-compose.yml up -d

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ endef
 define build_image_dev
 	$(ENV_DOCKER) build -t $(ENV_APISIX_IMAGE_TAG_NAME)-debian-dev \
 		--build-arg CODE_PATH=$(1) \
-		--build-arg ENTRYPOINT=debian-dev/docker-entrypoint.sh \
+		--build-arg ENTRYPOINT_PATH=debian-dev/docker-entrypoint.sh \
 		-f ./debian-dev/Dockerfile.local .
 endef
 

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,9 @@ APISIX_VERSION ?= 3.7.0
 MAX_APISIX_VERSION ?= 3.7.0
 IMAGE_NAME = apache/apisix
 IMAGE_TAR_NAME = apache_apisix
+APISIX_REPO = https://github.com/apache/apisix
+APISIX_REPO_BRANCH = master
+LOCAL_CODE_PATH = 0
 
 APISIX_DASHBOARD_VERSION ?= $(shell echo ${APISIX_DASHBOARD_VERSION:=3.0.1})
 APISIX_DASHBOARD_IMAGE_NAME = apache/apisix-dashboard
@@ -60,6 +63,12 @@ define func_echo_success_status
 	printf "[$(_color_green) info $(_color_wipe)] %s\n" $(1)
 endef
 
+define build_image_dev
+	$(ENV_DOCKER) build -t $(ENV_APISIX_IMAGE_TAG_NAME)-debian-dev \
+		--build-arg CODE_PATH=$(1) \
+		--build-arg ENTRYPOINT=debian-dev/docker-entrypoint.sh \
+		-f ./debian-dev/Dockerfile.local .
+endef
 
 ### build-on-redhat : Build apache/apisix:xx-redhat image
 .PHONY: build-on-redhat
@@ -75,6 +84,19 @@ build-on-debian-dev:
 	$(ENV_DOCKER) build -t $(ENV_APISIX_IMAGE_TAG_NAME)-debian-dev -f ./debian-dev/Dockerfile debian-dev
 	@$(call func_echo_success_status, "$@ -> [ Done ]")
 
+### build-on-debian-local-dev : Build apache/apisix:xx-debian-dev image
+.PHONY: build-on-debian-local-dev
+build-on-debian-local-dev:
+	@$(call func_echo_status, "$@ -> [ Start ]")
+ifeq ($(LOCAL_CODE_PATH), 0)
+ifeq ($(shell test -d ./apisix && echo -n yes), )
+	git clone -b $(APISIX_REPO_BRANCH) $(APISIX_REPO) ./apisix
+endif
+	$(call build_image_dev,"./apisix")
+else
+	$(call build_image_dev,$(LOCAL_CODE_PATH))
+endif
+	@$(call func_echo_success_status, "$@ -> [ Done ]")
 
 ### build-on-debian : Build apache/apisix:xx-debian image
 .PHONY: build-on-debian

--- a/debian-dev/Dockerfile.local
+++ b/debian-dev/Dockerfile.local
@@ -20,7 +20,6 @@
 FROM debian:bullseye-slim AS build
 
 ARG ENABLE_PROXY=false
-ARG ENTRYPOINT_PATH=./docker-entrypoint.sh
 ARG CODE_PATH
 
 ENV DEBIAN_FRONTEND noninteractive
@@ -43,6 +42,8 @@ RUN set -x \
     && make install
 
 FROM debian:bullseye-slim
+
+ARG ENTRYPOINT_PATH=./docker-entrypoint.sh
 
 COPY --from=build /usr/local/apisix /usr/local/apisix
 COPY --from=build /usr/local/openresty /usr/local/openresty

--- a/debian-dev/Dockerfile.local
+++ b/debian-dev/Dockerfile.local
@@ -17,71 +17,47 @@
 
 # Use this dockerfile to create a docker image of your apisix local/patched codebase
 
-FROM api7/apisix-runtime:dev AS build
+FROM debian:bullseye-slim AS build
 
 ARG ENABLE_PROXY=false
+ARG ENTRYPOINT_PATH=./docker-entrypoint.sh
+ARG CODE_PATH
 
 ENV DEBIAN_FRONTEND noninteractive
+ENV ENV_INST_LUADIR /usr/local/apisix
 
-# replace the source path with the location of apisix related directories in your host machine
-# refer: https://web.archive.org/web/20230604150902/https://www.jamestharpe.com/docker-include-files-outside-build-context/
+COPY ${CODE_PATH} /apisix
 
-COPY apisix/apisix /usr/local/apisix/apisix
-COPY apisix/conf /usr/local/apisix/conf
-COPY apisix/bin/apisix /usr/bin/apisix
-COPY apisix/apisix-master-0.rockspec /usr/local/apisix/apisix-master-0.rockspec
-COPY apisix/utils/linux-install-luarocks.sh /usr/local/apisix/linux-install-luarocks.sh
-COPY debian-dev/docker-entrypoint.sh /docker-entrypoint.sh
-
-
-WORKDIR /usr/local/apisix
-
-SHELL ["/bin/bash", "-c"]
+WORKDIR /apisix
 
 RUN set -x \
-    && DEBIAN_FRONTEND=noninteractive apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y libreadline-dev lsb-release libpcre3 libpcre3-dev libldap2-dev libssl-dev perl build-essential \
-    && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends wget gnupg ca-certificates
-
-RUN set -x \
-    && wget -O - https://openresty.org/package/pubkey.gpg | apt-key add - \
-    && wget -O - http://repos.apiseven.com/pubkey.gpg | apt-key add - \
-    && echo "deb http://openresty.org/package/debian bullseye openresty" | tee /etc/apt/sources.list.d/openresty.list \
-    && echo "deb http://repos.apiseven.com/packages/debian bullseye main" | tee /etc/apt/sources.list.d/apisix.list \
-    && DEBIAN_FRONTEND=noninteractive apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y apisix-runtime
-
-RUN set -x \
-    && (test "${ENABLE_PROXY}" != "true" || /bin/sed -i 's,http://deb.debian.org,http://mirrors.aliyun.com,g' /etc/apt/sources.list) \
     && apt-get -y update --fix-missing \
-    && apt-get install -y curl \
-        gawk \
-        git \
-        libldap2-dev \
-        liblua5.1-0-dev \
-        lua5.1 \
-        sudo \
-        unzip \
-        wget \
+    && apt-get install -y \
         make \
-        libssl-dev \
-    && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
-    && source "$HOME/.cargo/env" \
-    # rust version 1.69.0 required to compile lua-resty-ldap
-    && rustup install 1.69.0 \
-    && rustup default 1.69.0 \
-    && bash ./linux-install-luarocks.sh \
-    && luarocks config variables.OPENSSL_INCDIR /usr/include/ \
-    && luarocks config variables.PCRE_DIR /usr/local/openresty/pcre \
-    && luarocks install apisix-master-0.rockspec --tree=/usr/local/apisix/deps --deps-only \
-    && mkdir /usr/local/apisix/logs && touch /usr/local/apisix/logs/error.log && touch /usr/local/apisix/logs/access.log
+        git  \
+        sudo \
+    && ls -al \
+    && make deps \
+    && mkdir -p ${ENV_INST_LUADIR} \
+    && cp -r deps ${ENV_INST_LUADIR} \
+    && make install
+
+FROM debian:bullseye-slim
+
+COPY --from=build /usr/local/apisix /usr/local/apisix
+COPY --from=build /usr/local/openresty /usr/local/openresty
+COPY --from=build /usr/bin/apisix /usr/bin/apisix
 
 ENV PATH=$PATH:/usr/local/openresty/luajit/bin:/usr/local/openresty/nginx/sbin:/usr/local/openresty/bin
 
+WORKDIR /usr/local/apisix
+
+RUN ln -sf /dev/stdout /usr/local/apisix/logs/access.log \
+    && ln -sf /dev/stderr /usr/local/apisix/logs/error.log
+
 EXPOSE 9080 9443
 
-
-RUN ["chmod", "+x", "/docker-entrypoint.sh"]
+COPY ${ENTRYPOINT_PATH} /docker-entrypoint.sh
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 

--- a/debian-dev/docker-entrypoint.sh
+++ b/debian-dev/docker-entrypoint.sh
@@ -55,6 +55,10 @@ _EOC_
         rm -f "/usr/local/apisix/conf/config_listen.sock"
     fi
 
+    if [ -e "/usr/local/apisix/logs/worker_events.sock" ]; then
+        rm -f "/usr/local/apisix/logs/worker_events.sock"
+    fi
+
     exec /usr/local/openresty/bin/openresty -p /usr/local/apisix -g 'daemon off;'
 fi
 


### PR DESCRIPTION
Contains two fixes:

**1. Fix apisix-runtime dependency**

apisix is already dependent on the specified version of apisix-runtime.

**2. fix worker_events.sock address already.**

```shell
$ bin/apisix start
/usr/local/openresty//luajit/bin/luajit ./apisix/cli/apisix.lua start
nginx: [emerg] bind() to unix:/home/bzp/code/apisix/conf/worker_events.sock failed (98: Address already in use)
nginx: [emerg] bind() to unix:/home/bzp/code/apisix/conf/worker_events.sock failed (98: Address already in use)
```
ref: https://github.com/apache/apisix/pull/10732

The files `worker_events.sock` being exposed by container mounts and not being cleaned up on abnormal exits resulting in failure to start next time