### PR TITLE
chore: release APISIX 3.8.0

### DIFF
--- a/.github/workflows/apisix-docker-example-test-standalone.yaml
+++ b/.github/workflows/apisix-docker-example-test-standalone.yaml
@@ -14,7 +14,7 @@ on:
       - 'release/apisix-2.15.**'
 
 env:
-  APISIX_VERSION: "3.7.0"
+  APISIX_VERSION: "3.8.0"
 
 jobs:
   prepare:

--- a/.github/workflows/apisix-docker-example-test.yaml
+++ b/.github/workflows/apisix-docker-example-test.yaml
@@ -14,7 +14,7 @@ on:
       - 'release/apisix-2.15.**'
 
 env:
-  APISIX_VERSION: "3.7.0"
+  APISIX_VERSION: "3.8.0"
 
 jobs:
   prepare:

--- a/.github/workflows/apisix_push_docker_hub.yaml
+++ b/.github/workflows/apisix_push_docker_hub.yaml
@@ -13,7 +13,7 @@ jobs:
           - debian
           - redhat
     env:
-      APISIX_DOCKER_TAG: 3.7.0-${{ matrix.platform }}
+      APISIX_DOCKER_TAG: 3.8.0-${{ matrix.platform }}
 
     steps:
       - name: Check out the repo

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@ SHELL := bash
 
 
 # APISIX ARGS
-APISIX_VERSION ?= 3.7.0
-MAX_APISIX_VERSION ?= 3.7.0
+APISIX_VERSION ?= 3.8.0
+MAX_APISIX_VERSION ?= 3.8.0
 IMAGE_NAME = apache/apisix
 IMAGE_TAR_NAME = apache_apisix
 
@@ -90,7 +90,7 @@ push-multiarch-dev-on-debian:
 	@$(call func_echo_status, "$@ -> [ Start ]")
 	$(ENV_DOCKER) buildx build --network=host --push \
 		-t $(IMAGE_NAME):dev \
-		--platform linux/amd64,linux/arm64 \
+		--platform linux/amd64 \
 		-f ./debian-dev/Dockerfile debian-dev
 	@$(call func_echo_success_status, "$@ -> [ Done ]")
 
@@ -101,7 +101,7 @@ push-multiarch-on-debian:
 	@$(call func_echo_status, "$@ -> [ Start ]")
 	$(ENV_DOCKER) buildx build --network=host --push \
 		-t $(ENV_APISIX_IMAGE_TAG_NAME)-debian \
-		--platform linux/amd64,linux/arm64 \
+		--platform linux/amd64 \
 		-f ./debian/Dockerfile debian
 	@$(call func_echo_success_status, "$@ -> [ Done ]")
 

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -17,30 +17,26 @@
 
 FROM debian:bullseye-slim
 
-ARG APISIX_VERSION=3.7.0
+ARG APISIX_VERSION=3.8.0
 
 RUN set -ex; \
     arch=$(dpkg --print-architecture); \
     apt update; \
     apt-get -y install --no-install-recommends wget gnupg ca-certificates curl;\
     codename=`grep -Po 'VERSION="[0-9]+ \(\K[^)]+' /etc/os-release`; \
-    wget -O - https://openresty.org/package/pubkey.gpg | apt-key add -; \
     case "${arch}" in \
       amd64) \
-        echo "deb https://openresty.org/package/debian $codename openresty" | tee /etc/apt/sources.list.d/openresty.list \
-        && wget -O - https://repos.apiseven.com/pubkey.gpg | apt-key add - \
+        wget -O - https://repos.apiseven.com/pubkey.gpg | apt-key add - \
         && echo "deb https://repos.apiseven.com/packages/debian $codename main" | tee /etc/apt/sources.list.d/apisix.list \
         ;; \
       arm64) \
-        echo "deb https://openresty.org/package/arm64/debian $codename openresty" | tee /etc/apt/sources.list.d/openresty.list \
-        && wget -O - https://repos.apiseven.com/pubkey.gpg | apt-key add - \
+        wget -O - https://repos.apiseven.com/pubkey.gpg | apt-key add - \
         && echo "deb https://repos.apiseven.com/packages/arm64/debian $codename main" | tee /etc/apt/sources.list.d/apisix.list \
         ;; \
     esac; \
     apt update \
     && apt install -y apisix=${APISIX_VERSION}-0 \
     && apt-get purge -y --auto-remove \
-    && rm -f /etc/apt/sources.list.d/openresty.list /etc/apt/sources.list.d/apisix.list \
     && rm /usr/local/openresty/bin/etcdctl \
     && openresty -V \
     && apisix version

--- a/docs/en/latest/build.md
+++ b/docs/en/latest/build.md
@@ -43,7 +43,7 @@ Find an APISIX [release version](https://github.com/apache/apisix/releases) to b
 Build a Docker image from the release:
 
 ```shell
-APISIX_VERSION=3.7.0    # specify release version
+APISIX_VERSION=3.8.0    # specify release version
 DISTRO=debian           # debian, redhat
 make build-on-$DISTRO
 ```

--- a/example/docker-compose-arm64.yml
+++ b/example/docker-compose-arm64.yml
@@ -19,7 +19,7 @@ version: "3"
 
 services:
   apisix:
-    image: apache/apisix:3.7.0-debian
+    image: apache/apisix:3.8.0-debian
     restart: always
     volumes:
       - ./apisix_conf/config.yaml:/usr/local/apisix/conf/config.yaml:ro

--- a/example/docker-compose-standalone.yml
+++ b/example/docker-compose-standalone.yml
@@ -19,7 +19,7 @@ version: "3"
 
 services:
   apisix:
-    image: apache/apisix:${APISIX_IMAGE_TAG:-3.7.0-debian}
+    image: apache/apisix:${APISIX_IMAGE_TAG:-3.8.0-debian}
     restart: always
     volumes:
       - ./apisix_conf/apisix-standalone.yaml:/usr/local/apisix/conf/apisix.yaml:ro

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -19,7 +19,7 @@ version: "3"
 
 services:
   apisix:
-    image: apache/apisix:${APISIX_IMAGE_TAG:-3.7.0-debian}
+    image: apache/apisix:${APISIX_IMAGE_TAG:-3.8.0-debian}
     restart: always
     volumes:
       - ./apisix_conf/config.yaml:/usr/local/apisix/conf/config.yaml:ro
@@ -36,7 +36,7 @@ services:
       apisix:
 
   etcd:
-    image: bitnami/etcd:3.4.15
+    image: bitnami/etcd:3.5.11
     restart: always
     volumes:
       - etcd_data:/bitnami/etcd

--- a/redhat/Dockerfile
+++ b/redhat/Dockerfile
@@ -17,7 +17,7 @@
 
 FROM registry.access.redhat.com/ubi8/ubi:8.6
 
-ARG APISIX_VERSION=3.7.0
+ARG APISIX_VERSION=3.8.0
 LABEL apisix_version="${APISIX_VERSION}"
 COPY ./yum.repos.d/apache-apisix.repo /etc/yum.repos.d/apache-apisix.repo
 COPY ./yum.repos.d/openresty.repo /etc/yum.repos.d/openresty.repo

--- a/redhat/docker-entrypoint.sh
+++ b/redhat/docker-entrypoint.sh
@@ -54,6 +54,10 @@ _EOC_
     if [ -e "/usr/local/apisix/conf/config_listen.sock" ]; then
         rm -f "/usr/local/apisix/conf/config_listen.sock"
     fi
+
+    if [ -e "/usr/local/apisix/logs/worker_events.sock" ]; then
+        rm -f "/usr/local/apisix/logs/worker_events.sock"
+    fi
     
     exec /usr/local/openresty/bin/openresty -p /usr/local/apisix -g 'daemon off;'
 fi


### PR DESCRIPTION
Due to the missing deb/rpm arm architecture package, image with arm architecture is currently not supported.