### PR TITLE
chore: install brotli for debian and redhat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,7 @@ define build_image_dev
 	$(ENV_DOCKER) build -t $(ENV_APISIX_IMAGE_TAG_NAME)-debian-dev \
 		--build-arg CODE_PATH=$(1) \
 		--build-arg ENTRYPOINT_PATH=debian-dev/docker-entrypoint.sh \
+		--build-arg INSTALL_BROTLI=debian-dev/install-brotli.sh \
 		-f ./debian-dev/Dockerfile.local .
 endef
 

--- a/debian-dev/Dockerfile
+++ b/debian-dev/Dockerfile
@@ -53,7 +53,7 @@ RUN apt-get -y update --fix-missing \
         libldap2-dev \
     && apt-get remove --purge --auto-remove -y
 
-COPY install-brotli.sh /install-brotli.sh
+COPY ./install-brotli.sh /install-brotli.sh
 RUN chmod +x /install-brotli.sh \  
     && cd / && ./install-brotli.sh && rm -rf /install-brotli.sh
 

--- a/debian-dev/Dockerfile
+++ b/debian-dev/Dockerfile
@@ -53,6 +53,10 @@ RUN apt-get -y update --fix-missing \
         libldap2-dev \
     && apt-get remove --purge --auto-remove -y
 
+COPY install-brotli.sh /install-brotli.sh
+RUN chmod +x /install-brotli.sh \  
+    && cd / && ./install-brotli.sh && rm -rf /install-brotli.sh
+
 WORKDIR /usr/local/apisix
 
 ENV PATH=$PATH:/usr/local/openresty/luajit/bin:/usr/local/openresty/nginx/sbin:/usr/local/openresty/bin

--- a/debian-dev/Dockerfile.local
+++ b/debian-dev/Dockerfile.local
@@ -49,6 +49,10 @@ COPY --from=build /usr/local/apisix /usr/local/apisix
 COPY --from=build /usr/local/openresty /usr/local/openresty
 COPY --from=build /usr/bin/apisix /usr/bin/apisix
 
+COPY install-brotli.sh /install-brotli.sh
+RUN chmod +x /install-brotli.sh \  
+    && cd / && ./install-brotli.sh && rm -rf /install-brotli.sh
+
 ENV PATH=$PATH:/usr/local/openresty/luajit/bin:/usr/local/openresty/nginx/sbin:/usr/local/openresty/bin
 
 WORKDIR /usr/local/apisix

--- a/debian-dev/Dockerfile.local
+++ b/debian-dev/Dockerfile.local
@@ -44,12 +44,13 @@ RUN set -x \
 FROM debian:bullseye-slim
 
 ARG ENTRYPOINT_PATH=./docker-entrypoint.sh
+ARG INSTALL_BROTLI=./install-brotli.sh
 
 COPY --from=build /usr/local/apisix /usr/local/apisix
 COPY --from=build /usr/local/openresty /usr/local/openresty
 COPY --from=build /usr/bin/apisix /usr/bin/apisix
 
-COPY install-brotli.sh /install-brotli.sh
+COPY ${INSTALL_BROTLI} /install-brotli.sh
 RUN chmod +x /install-brotli.sh \  
     && cd / && ./install-brotli.sh && rm -rf /install-brotli.sh
 

--- a/debian-dev/install-brotli.sh
+++ b/debian-dev/install-brotli.sh
@@ -1,0 +1,23 @@
+install_brotli () {
+    apt-get install -y sudo cmake wget unzip
+    local BORTLI_VERSION="1.1.0"
+    wget -q https://github.com/google/brotli/archive/refs/tags/v${BORTLI_VERSION}.zip || exit -1 
+    unzip v${BORTLI_VERSION}.zip && cd ./brotli-${BORTLI_VERSION} && mkdir build && cd build || exit -1 
+    local CMAKE=$(command -v cmake3 > /dev/null 2>&1 && echo cmake3 || echo cmake) || exit -1 
+    ${CMAKE} -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local/brotli .. || exit -1 
+    sudo ${CMAKE} --build . --config Release --target install || exit -1
+    if [ -d "/usr/local/brotli/lib64" ]; then
+        echo /usr/local/brotli/lib64 | sudo tee /etc/ld.so.conf.d/brotli.conf
+    else
+        echo /usr/local/brotli/lib | sudo tee /etc/ld.so.conf.d/brotli.conf
+    fi
+    sudo ldconfig || exit -1
+    ln -sf /usr/local/brotli/bin/brotli /usr/bin/brotli
+    cd ../..
+    rm -rf brotli-${BORTLI_VERSION}
+    rm -rf /v${BORTLI_VERSION}.zip
+    export SUDO_FORCE_REMOVE=yes
+    apt purge -qy cmake sudo wget unzip
+    apt-get remove --purge --auto-remove -y
+}
+install_brotli

--- a/debian-dev/install-brotli.sh
+++ b/debian-dev/install-brotli.sh
@@ -1,4 +1,5 @@
 install_brotli () {
+    apt-get -qy update
     apt-get install -y sudo cmake wget unzip
     local BORTLI_VERSION="1.1.0"
     wget -q https://github.com/google/brotli/archive/refs/tags/v${BORTLI_VERSION}.zip || exit -1 

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -41,7 +41,7 @@ RUN set -ex; \
     && openresty -V \
     && apisix version
 
-COPY install-brotli.sh /install-brotli.sh
+COPY ./install-brotli.sh /install-brotli.sh
 RUN chmod +x /install-brotli.sh \  
     && cd / && ./install-brotli.sh && rm -rf /install-brotli.sh
 

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -41,6 +41,10 @@ RUN set -ex; \
     && openresty -V \
     && apisix version
 
+COPY install-brotli.sh /install-brotli.sh
+RUN chmod +x /install-brotli.sh \  
+    && cd / && ./install-brotli.sh && rm -rf /install-brotli.sh
+
 RUN apt-get -y purge --auto-remove curl wget gnupg --allow-remove-essential
 
 WORKDIR /usr/local/apisix

--- a/debian/install-brotli.sh
+++ b/debian/install-brotli.sh
@@ -1,0 +1,23 @@
+install_brotli () {
+    apt-get install -y sudo cmake wget unzip
+    local BORTLI_VERSION="1.1.0"
+    wget -q https://github.com/google/brotli/archive/refs/tags/v${BORTLI_VERSION}.zip || exit -1 
+    unzip v${BORTLI_VERSION}.zip && cd ./brotli-${BORTLI_VERSION} && mkdir build && cd build || exit -1 
+    local CMAKE=$(command -v cmake3 > /dev/null 2>&1 && echo cmake3 || echo cmake) || exit -1 
+    ${CMAKE} -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local/brotli .. || exit -1 
+    sudo ${CMAKE} --build . --config Release --target install || exit -1
+    if [ -d "/usr/local/brotli/lib64" ]; then
+        echo /usr/local/brotli/lib64 | sudo tee /etc/ld.so.conf.d/brotli.conf
+    else
+        echo /usr/local/brotli/lib | sudo tee /etc/ld.so.conf.d/brotli.conf
+    fi
+    sudo ldconfig || exit -1
+    ln -sf /usr/local/brotli/bin/brotli /usr/bin/brotli
+    cd ../..
+    rm -rf brotli-${BORTLI_VERSION}
+    rm -rf /v${BORTLI_VERSION}.zip
+    export SUDO_FORCE_REMOVE=yes
+    apt purge -qy cmake sudo wget unzip
+    apt-get remove --purge --auto-remove -y
+}
+install_brotli

--- a/redhat/Dockerfile
+++ b/redhat/Dockerfile
@@ -27,6 +27,10 @@ RUN yum update -y \
 	&& yum clean all \
 	&& sed -i 's/PASS_MAX_DAYS\t99999/PASS_MAX_DAYS\t60/g' /etc/login.defs
 
+COPY ./install-brotli.sh /install-brotli.sh
+RUN chmod +x /install-brotli.sh \
+    && cd / && ./install-brotli.sh && rm -rf /install-brotli.sh
+
 WORKDIR /usr/local/apisix
 
 ENV PATH=$PATH:/usr/local/openresty/luajit/bin:/usr/local/openresty/nginx/sbin:/usr/local/openresty/bin

--- a/redhat/install-brotli.sh
+++ b/redhat/install-brotli.sh
@@ -1,0 +1,24 @@
+install_brotli () {
+    yum install -y sudo cmake3 wget unzip gcc
+    export PATH=$PATH:/usr/local/bin
+    local BORTLI_VERSION="1.1.0"
+    wget -q https://github.com/google/brotli/archive/refs/tags/v${BORTLI_VERSION}.zip || exit -1
+    unzip v${BORTLI_VERSION}.zip && cd ./brotli-${BORTLI_VERSION} && mkdir build && cd build || exit -1
+    local CMAKE=$(command -v cmake3 > /dev/null 2>&1 && echo cmake3 || echo cmake) || exit -1
+    ${CMAKE} -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local/brotli .. || exit -1
+    sudo ${CMAKE} --build . --config Release --target install || exit -1
+    if [ -d "/usr/local/brotli/lib64" ]; then
+        echo /usr/local/brotli/lib64 | sudo tee /etc/ld.so.conf.d/brotli.conf
+    else
+        echo /usr/local/brotli/lib | sudo tee /etc/ld.so.conf.d/brotli.conf
+    fi
+    sudo ldconfig || exit -1
+    ln -sf /usr/local/brotli/bin/brotli /usr/bin/brotli
+    cd ../..
+    rm -rf brotli-${BORTLI_VERSION}
+    rm -rf /v${BORTLI_VERSION}.zip
+    yum remove -y cmake3 wget unzip gcc
+    rm -rf /usr/bin/sudo
+    yum clean all -y
+}
+install_brotli


### PR DESCRIPTION
This PR installs `brotli` on debain docker to use `brolti` plugin. 
- #530

Fixes #530 

Brolti is required to use the `brotli` plugin released in version 3.8.0 and above.
