### PR TITLE
ci: support uploading images of arm architecture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ push-multiarch-dev-on-debian:
 	@$(call func_echo_status, "$@ -> [ Start ]")
 	$(ENV_DOCKER) buildx build --network=host --push \
 		-t $(IMAGE_NAME):dev \
-		--platform linux/amd64 \
+		--platform linux/amd64,linux/arm64 \
 		-f ./debian-dev/Dockerfile debian-dev
 	@$(call func_echo_success_status, "$@ -> [ Done ]")
 
@@ -124,7 +124,7 @@ push-multiarch-on-debian:
 	@$(call func_echo_status, "$@ -> [ Start ]")
 	$(ENV_DOCKER) buildx build --network=host --push \
 		-t $(ENV_APISIX_IMAGE_TAG_NAME)-debian \
-		--platform linux/amd64 \
+		--platform linux/amd64,linux/arm64 \
 		-f ./debian/Dockerfile debian
 	@$(call func_echo_success_status, "$@ -> [ Done ]")
 
@@ -135,7 +135,7 @@ push-multiarch-on-redhat:
 	@$(call func_echo_status, "$@ -> [ Start ]")
 	$(ENV_DOCKER) buildx build --network=host --push \
 		-t $(ENV_APISIX_IMAGE_TAG_NAME)-redhat \
-		--platform linux/amd64 \
+		--platform linux/amd64,linux/arm64 \
 		-f ./redhat/Dockerfile redhat
 	@$(call func_echo_success_status, "$@ -> [ Done ]")
 
@@ -149,7 +149,7 @@ push-multiarch-on-latest:
 	@if [ "$(shell echo "$(APISIX_VERSION) $(MAX_APISIX_VERSION)" | tr " " "\n" | sort -rV | head -n 1)" == "$(APISIX_VERSION)" ]; then \
 		$(ENV_DOCKER) buildx build --network=host --push \
 			-t $(IMAGE_NAME):latest \
-			--platform linux/amd64 \
+			--platform linux/amd64,linux/arm64 \
 			-f ./debian/Dockerfile debian; \
 	fi
 	@$(call func_echo_success_status, "$@ -> [ Done ]")

--- a/all-in-one/apisix-dashboard/Dockerfile
+++ b/all-in-one/apisix-dashboard/Dockerfile
@@ -101,6 +101,8 @@ COPY --from=pre-build /usr/local/apisix-dashboard .
 WORKDIR /usr/local/apisix-dashboard/web
 
 RUN if [ "$ENABLE_PROXY" = "true" ] ; then yarn config set registry https://registry.npmmirror.com/ ; fi \
+    # FIXME: when the certificate is valid
+    && yarn config set "strict-ssl" false -g \
     && yarn install \
     && yarn build
 


### PR DESCRIPTION
It is known that publishing images depends on the rpm/deb package.

The apisix already supports publishing deb/rpm packages for ARM architecture.

https://github.com/api7/apisix-build-tools/actions/runs/7730314755