### PR TITLE
feat: Add automatic key generation in docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,9 +118,9 @@ deployment:
                   # If not set, by default all IP access is allowed.
     admin_key:
       - name: "admin"
-# Please set this to a random 32 character alphanumeric. This is automatically set while using docker compose. 
+# Please set this to a random 32 character alphanumeric. This is automatically set while using docker compose.
 #If not provided then apisix will autogenerate one and write it here. In that case, make sure that this is the only apisix instance using this config
-        role: admin 
+        role: admin
         key: ''  
   etcd:
     host:

--- a/README.md
+++ b/README.md
@@ -116,6 +116,12 @@ deployment:
     allow_admin:
       - 0.0.0.0/0  # Please set it to the subnet address you obtained.
                   # If not set, by default all IP access is allowed.
+    admin_key:
+      - name: "admin"
+# Please set this to a random 32 character alphanumeric. This is automatically set while using docker compose. 
+#If not provided then apisix will autogenerate one and write it here. In that case, make sure that this is the only apisix instance using this config
+        role: admin 
+        key: ''  
   etcd:
     host:
       - "http://etcd:2379"
@@ -141,7 +147,7 @@ Check that APISIX is running properly by running the following command on the ho
 
 ```
 curl "http://127.0.0.1:9180/apisix/admin/services/" \
--H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1'
+-H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' # Replace this key with the one either provided by you, or written by apisix in the config.yaml
 ```
 
 The response indicates that apisix is running successfully:

--- a/all-in-one/apisix-dashboard/Dockerfile
+++ b/all-in-one/apisix-dashboard/Dockerfile
@@ -33,6 +33,7 @@ RUN set -x \
     automake \
     autoconf \
     libtool \
+    libyaml-dev \
     pkgconfig \
     cmake \
     git \

--- a/compose/apisix_conf/master/config.yaml
+++ b/compose/apisix_conf/master/config.yaml
@@ -26,7 +26,7 @@ deployment:
 
     admin_key:
       - name: "admin"
-        key: edd1c9f034335f136f87ad84b625c8f1
+        key: ''
         role: admin                 # admin: manage all configuration data
 
   etcd:

--- a/compose/apisix_conf/release/config.yaml
+++ b/compose/apisix_conf/release/config.yaml
@@ -26,7 +26,7 @@ deployment:
 
     admin_key:
       - name: "admin"
-        key: edd1c9f034335f136f87ad84b625c8f1
+        key: ''
         role: admin                 # admin: manage all configuration data
 
   etcd:

--- a/compose/docker-compose-master.yaml
+++ b/compose/docker-compose-master.yaml
@@ -25,6 +25,7 @@ services:
       - ./apisix_conf/master/config.yaml:/usr/local/apisix/conf/config.yaml:ro
     depends_on:
       - etcd
+      - modify_config
     ports:
       - "9180:9180/tcp"
       - "9080:9080/tcp"
@@ -32,6 +33,13 @@ services:
       - "9443:9443/tcp"
     networks:
       - apisix
+
+  modify_config: # You can remove this service if you already have added your own key for admin api in the config
+      image: alpine:latest
+      volumes:
+        - ./apisix_conf/master/config.yaml:/config.yaml:rw
+        - ./modify_config.sh:/modify_config.sh:ro
+      command: ["/bin/sh", "/modify_config.sh"]
 
   etcd:
     image: bitnami/etcd:3.4.9

--- a/compose/docker-compose-release.yaml
+++ b/compose/docker-compose-release.yaml
@@ -25,6 +25,7 @@ services:
       - ./apisix_conf/release/config.yaml:/usr/local/apisix/conf/config.yaml:ro
     depends_on:
       - etcd
+      - modify_config
     ports:
       - "9180:9180/tcp"
       - "9080:9080/tcp"
@@ -32,6 +33,13 @@ services:
       - "9443:9443/tcp"
     networks:
       - apisix
+
+  modify_config: # You can remove this service if you already have added your own key for admin api in the config
+      image: alpine:latest
+      volumes:
+        - ./apisix_conf/master/config.yaml:/config.yaml:rw
+        - ./modify_config.sh:/modify_config.sh:ro
+      command: ["/bin/sh", "/modify_config.sh"]
 
   etcd:
     image: bitnami/etcd:3.4.9

--- a/compose/modify_config.sh
+++ b/compose/modify_config.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# Generate a random string
+random_string=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 32)
+
+# Perform substitution using sed
+sed "s/key: ''/key: $random_string/g" /config.yaml > /tmp/temp_config.yaml
+
+# Copy the content of the temporary file back to the original file
+cat /tmp/temp_config.yaml > /config.yaml
+
+# Remove the temporary file
+rm /tmp/temp_config.yaml


### PR DESCRIPTION
This PR is part of the proposal which removes hardcoding of sensitive API keys by autogenerating them at either application level(APISIX) or deployment level(like docker.)