### PR TITLE
fix: avoid config.yaml modification in standalone mode due to read only file system.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,14 +75,18 @@ endef
 .PHONY: build-on-redhat
 build-on-redhat:
 	@$(call func_echo_status, "$@ -> [ Start ]")
+	cp ./utils/check_standalone_config.sh redhat/check_standalone_config.sh
 	$(ENV_DOCKER) build -t $(ENV_APISIX_IMAGE_TAG_NAME)-redhat -f ./redhat/Dockerfile redhat
+	rm -f redhat/check_standalone_config.sh
 	@$(call func_echo_success_status, "$@ -> [ Done ]")
 
 ### build-on-debian-dev : Build apache/apisix:xx-debian-dev image
 .PHONY: build-on-debian-dev
 build-on-debian-dev:
 	@$(call func_echo_status, "$@ -> [ Start ]")
+	cp ./utils/check_standalone_config.sh debian-dev/check_standalone_config.sh
 	$(ENV_DOCKER) build -t $(ENV_APISIX_IMAGE_TAG_NAME)-debian-dev -f ./debian-dev/Dockerfile debian-dev
+	rm -f debian-dev/check_standalone_config.sh
 	@$(call func_echo_success_status, "$@ -> [ Done ]")
 
 ### build-on-debian-local-dev : Build apache/apisix:xx-debian-dev image
@@ -103,7 +107,9 @@ endif
 .PHONY: build-on-debian
 build-on-debian:
 	@$(call func_echo_status, "$@ -> [ Start ]")
+	cp ./utils/check_standalone_config.sh debian/check_standalone_config.sh
 	$(ENV_DOCKER) build -t $(ENV_APISIX_IMAGE_TAG_NAME)-debian -f ./debian/Dockerfile debian
+	rm -f debian/check_standalone_config.sh
 	@$(call func_echo_success_status, "$@ -> [ Done ]")
 
 
@@ -111,10 +117,12 @@ build-on-debian:
 .PHONY: push-multiarch-dev-on-debian
 push-multiarch-dev-on-debian:
 	@$(call func_echo_status, "$@ -> [ Start ]")
+	cp ./utils/check_standalone_config.sh debian-dev/check_standalone_config.sh
 	$(ENV_DOCKER) buildx build --network=host --push \
 		-t $(IMAGE_NAME):dev \
 		--platform linux/amd64,linux/arm64 \
 		-f ./debian-dev/Dockerfile debian-dev
+	rm -f debian-dev/check_standalone_config.sh
 	@$(call func_echo_success_status, "$@ -> [ Done ]")
 
 
@@ -122,10 +130,12 @@ push-multiarch-dev-on-debian:
 .PHONY: push-multiarch-on-debian
 push-multiarch-on-debian:
 	@$(call func_echo_status, "$@ -> [ Start ]")
+	cp ./utils/check_standalone_config.sh debian/check_standalone_config.sh
 	$(ENV_DOCKER) buildx build --network=host --push \
 		-t $(ENV_APISIX_IMAGE_TAG_NAME)-debian \
 		--platform linux/amd64,linux/arm64 \
 		-f ./debian/Dockerfile debian
+	rm -f debian/check_standalone_config.sh
 	@$(call func_echo_success_status, "$@ -> [ Done ]")
 
 
@@ -133,10 +143,12 @@ push-multiarch-on-debian:
 .PHONY: push-multiarch-on-redhat
 push-multiarch-on-redhat:
 	@$(call func_echo_status, "$@ -> [ Start ]")
+	cp ./utils/check_standalone_config.sh redhat/check_standalone_config.sh
 	$(ENV_DOCKER) buildx build --network=host --push \
 		-t $(ENV_APISIX_IMAGE_TAG_NAME)-redhat \
 		--platform linux/amd64,linux/arm64 \
 		-f ./redhat/Dockerfile redhat
+	rm -f redhat/check_standalone_config.sh
 	@$(call func_echo_success_status, "$@ -> [ Done ]")
 
 ### push-multiarch-on-latest : Push apache/apisix:latest image
@@ -147,10 +159,12 @@ push-multiarch-on-redhat:
 push-multiarch-on-latest:
 	@$(call func_echo_status, "$@ -> [ Start ]")
 	@if [ "$(shell echo "$(APISIX_VERSION) $(MAX_APISIX_VERSION)" | tr " " "\n" | sort -rV | head -n 1)" == "$(APISIX_VERSION)" ]; then \
+		cp ./utils/check_standalone_config.sh debian/check_standalone_config.sh; \
 		$(ENV_DOCKER) buildx build --network=host --push \
 			-t $(IMAGE_NAME):latest \
 			--platform linux/amd64,linux/arm64 \
 			-f ./debian/Dockerfile debian; \
+		rm -f debian/check_standalone_config.sh; \
 	fi
 	@$(call func_echo_success_status, "$@ -> [ Done ]")
 

--- a/debian-dev/Dockerfile
+++ b/debian-dev/Dockerfile
@@ -64,6 +64,7 @@ ENV PATH=$PATH:/usr/local/openresty/luajit/bin:/usr/local/openresty/nginx/sbin:/
 EXPOSE 9080 9443
 
 COPY ./docker-entrypoint.sh /docker-entrypoint.sh
+COPY ./utils/check_standalone_config.sh /check_standalone_config.sh
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 

--- a/debian-dev/Dockerfile.local
+++ b/debian-dev/Dockerfile.local
@@ -66,6 +66,7 @@ RUN ln -sf /dev/stdout /usr/local/apisix/logs/access.log \
 EXPOSE 9080 9443
 
 COPY ${ENTRYPOINT_PATH} /docker-entrypoint.sh
+COPY ../utils/check_standalone_config.sh /check_standalone_config.sh
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 

--- a/debian-dev/docker-entrypoint.sh
+++ b/debian-dev/docker-entrypoint.sh
@@ -31,11 +31,24 @@ deployment:
     config_provider: yaml
 _EOC_
       else
-          # updating config.yaml for standalone mode
-          echo "$(sed 's/role: traditional/role: data_plane/g' ${PREFIX}/conf/config.yaml)" > ${PREFIX}/conf/config.yaml
-          echo "$(sed 's/role_traditional:/role_data_plane:/g' ${PREFIX}/conf/config.yaml)" > ${PREFIX}/conf/config.yaml
-          echo "$(sed 's/config_provider: etcd/config_provider: yaml/g' ${PREFIX}/conf/config.yaml)" > ${PREFIX}/conf/config.yaml
+          # Check if the deployment role is set to data_plane and config provider is set to yaml for standalone mode
+          if ! grep -q 'role: data_plane' "${PREFIX}/conf/config.yaml"; then
+            echo "Error: ${PREFIX}/conf/config.yaml does not contain 'role: data_plane'. Deployment role must be set to 'data_plane' for standalone mode."
+            echo "Please refer to the APISIX documentation for deployment modes: https://apisix.apache.org/docs/apisix/deployment-modes/"
+            exit 1
+          fi
 
+          if ! grep -q 'role_data_plane:' "${PREFIX}/conf/config.yaml"; then
+              echo "Error: ${PREFIX}/conf/config.yaml does not contain 'role_data_plane:'."
+              echo "Please refer to the APISIX documentation for deployment modes: https://apisix.apache.org/docs/apisix/deployment-modes/"
+              exit 1
+          fi
+
+          if ! grep -q 'config_provider: yaml' "${PREFIX}/conf/config.yaml"; then
+              echo "Error: ${PREFIX}/conf/config.yaml does not contain 'config_provider: yaml'. Config provider must be set to 'yaml' for standalone mode."
+              echo "Please refer to the APISIX documentation for deployment modes: https://apisix.apache.org/docs/apisix/deployment-modes/"
+              exit 1
+          fi
       fi
 
         if [ ! -f "${PREFIX}/conf/apisix.yaml" ]; then

--- a/debian-dev/docker-entrypoint.sh
+++ b/debian-dev/docker-entrypoint.sh
@@ -32,23 +32,7 @@ deployment:
 _EOC_
       else
           # Check if the deployment role is set to data_plane and config provider is set to yaml for standalone mode
-          if ! grep -q 'role: data_plane' "${PREFIX}/conf/config.yaml"; then
-            echo "Error: ${PREFIX}/conf/config.yaml does not contain 'role: data_plane'. Deployment role must be set to 'data_plane' for standalone mode."
-            echo "Please refer to the APISIX documentation for deployment modes: https://apisix.apache.org/docs/apisix/deployment-modes/"
-            exit 1
-          fi
-
-          if ! grep -q 'role_data_plane:' "${PREFIX}/conf/config.yaml"; then
-              echo "Error: ${PREFIX}/conf/config.yaml does not contain 'role_data_plane:'."
-              echo "Please refer to the APISIX documentation for deployment modes: https://apisix.apache.org/docs/apisix/deployment-modes/"
-              exit 1
-          fi
-
-          if ! grep -q 'config_provider: yaml' "${PREFIX}/conf/config.yaml"; then
-              echo "Error: ${PREFIX}/conf/config.yaml does not contain 'config_provider: yaml'. Config provider must be set to 'yaml' for standalone mode."
-              echo "Please refer to the APISIX documentation for deployment modes: https://apisix.apache.org/docs/apisix/deployment-modes/"
-              exit 1
-          fi
+          source /check_standalone_config.sh
       fi
 
         if [ ! -f "${PREFIX}/conf/apisix.yaml" ]; then

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -64,6 +64,7 @@ RUN ln -sf /dev/stdout /usr/local/apisix/logs/access.log \
 EXPOSE 9080 9443
 
 COPY ./docker-entrypoint.sh /docker-entrypoint.sh
+COPY ./check_standalone_config.sh /check_standalone_config.sh
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 

--- a/debian/docker-entrypoint.sh
+++ b/debian/docker-entrypoint.sh
@@ -31,10 +31,24 @@ deployment:
     config_provider: yaml
 _EOC_
       else
-          # updating config.yaml for standalone mode
-          echo "$(sed 's/role: traditional/role: data_plane/g' ${PREFIX}/conf/config.yaml)" > ${PREFIX}/conf/config.yaml
-          echo "$(sed 's/role_traditional:/role_data_plane:/g' ${PREFIX}/conf/config.yaml)" > ${PREFIX}/conf/config.yaml
-          echo "$(sed 's/config_provider: etcd/config_provider: yaml/g' ${PREFIX}/conf/config.yaml)" > ${PREFIX}/conf/config.yaml
+          # Check if the deployment role is set to data_plane and config provider is set to yaml for standalone mode
+          if ! grep -q 'role: data_plane' "${PREFIX}/conf/config.yaml"; then
+            echo "Error: ${PREFIX}/conf/config.yaml does not contain 'role: data_plane'. Deployment role must be set to 'data_plane' for standalone mode."
+            echo "Please refer to the APISIX documentation for deployment modes: https://apisix.apache.org/docs/apisix/deployment-modes/"
+            exit 1
+          fi
+
+          if ! grep -q 'role_data_plane:' "${PREFIX}/conf/config.yaml"; then
+              echo "Error: ${PREFIX}/conf/config.yaml does not contain 'role_data_plane:'."
+              echo "Please refer to the APISIX documentation for deployment modes: https://apisix.apache.org/docs/apisix/deployment-modes/"
+              exit 1
+          fi
+
+          if ! grep -q 'config_provider: yaml' "${PREFIX}/conf/config.yaml"; then
+              echo "Error: ${PREFIX}/conf/config.yaml does not contain 'config_provider: yaml'. Config provider must be set to 'yaml' for standalone mode."
+              echo "Please refer to the APISIX documentation for deployment modes: https://apisix.apache.org/docs/apisix/deployment-modes/"
+              exit 1
+          fi
       fi
 
         if [ ! -f "${PREFIX}/conf/apisix.yaml" ]; then

--- a/debian/docker-entrypoint.sh
+++ b/debian/docker-entrypoint.sh
@@ -32,23 +32,7 @@ deployment:
 _EOC_
       else
           # Check if the deployment role is set to data_plane and config provider is set to yaml for standalone mode
-          if ! grep -q 'role: data_plane' "${PREFIX}/conf/config.yaml"; then
-            echo "Error: ${PREFIX}/conf/config.yaml does not contain 'role: data_plane'. Deployment role must be set to 'data_plane' for standalone mode."
-            echo "Please refer to the APISIX documentation for deployment modes: https://apisix.apache.org/docs/apisix/deployment-modes/"
-            exit 1
-          fi
-
-          if ! grep -q 'role_data_plane:' "${PREFIX}/conf/config.yaml"; then
-              echo "Error: ${PREFIX}/conf/config.yaml does not contain 'role_data_plane:'."
-              echo "Please refer to the APISIX documentation for deployment modes: https://apisix.apache.org/docs/apisix/deployment-modes/"
-              exit 1
-          fi
-
-          if ! grep -q 'config_provider: yaml' "${PREFIX}/conf/config.yaml"; then
-              echo "Error: ${PREFIX}/conf/config.yaml does not contain 'config_provider: yaml'. Config provider must be set to 'yaml' for standalone mode."
-              echo "Please refer to the APISIX documentation for deployment modes: https://apisix.apache.org/docs/apisix/deployment-modes/"
-              exit 1
-          fi
+          source /check_standalone_config.sh
       fi
 
         if [ ! -f "${PREFIX}/conf/apisix.yaml" ]; then

--- a/example/apisix_conf/config-standalone.yaml
+++ b/example/apisix_conf/config-standalone.yaml
@@ -15,41 +15,11 @@
 # limitations under the License.
 #
 
-version: "3"
+apisix:
+  node_listen: 9080              # APISIX listening port
+  enable_ipv6: false
 
-services:
-  apisix:
-    image: apache/apisix:${APISIX_IMAGE_TAG:-3.9.0-debian}
-    restart: always
-    volumes:
-      - ./apisix_conf/apisix-standalone.yaml:/usr/local/apisix/conf/apisix.yaml:ro
-      - ./apisix_conf/config-standalone.yaml:/usr/local/apisix/conf/config.yaml:ro
-    environment:
-      - APISIX_STAND_ALONE=true
-    ports:
-      - "9180:9180/tcp"
-      - "9080:9080/tcp"
-      - "9091:9091/tcp"
-      - "9443:9443/tcp"
-      - "9092:9092/tcp"
-    networks:
-      apisix:
-
-  web1:
-    image: nginx:1.19.0-alpine
-    restart: always
-    volumes:
-      - ./upstream/web1.conf:/etc/nginx/nginx.conf
-    ports:
-      - "9081:80/tcp"
-    environment:
-      - NGINX_PORT=80
-    networks:
-      apisix:
-
-
-networks:
-  apisix:
-    driver: bridge
-
-
+deployment:
+  role: data_plane
+  role_data_plane:
+    config_provider: yaml

--- a/redhat/Dockerfile
+++ b/redhat/Dockerfile
@@ -43,6 +43,7 @@ RUN ln -sf /dev/stdout /usr/local/apisix/logs/access.log \
 EXPOSE 9080 9443
 
 COPY ./docker-entrypoint.sh /docker-entrypoint.sh
+COPY ./check_standalone_config.sh /check_standalone_config.sh
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 

--- a/redhat/docker-entrypoint.sh
+++ b/redhat/docker-entrypoint.sh
@@ -31,10 +31,29 @@ deployment:
     config_provider: yaml
 _EOC_
       else
-          # updating config.yaml for standalone mode
-          echo "$(sed 's/role: traditional/role: data_plane/g' ${PREFIX}/conf/config.yaml)" > ${PREFIX}/conf/config.yaml
-          echo "$(sed 's/role_traditional:/role_data_plane:/g' ${PREFIX}/conf/config.yaml)" > ${PREFIX}/conf/config.yaml
-          echo "$(sed 's/config_provider: etcd/config_provider: yaml/g' ${PREFIX}/conf/config.yaml)" > ${PREFIX}/conf/config.yaml
+          # Check if the deployment role is set to data_plane and config provider is set to yaml for standalone mode
+          if ! grep -q 'role: data_plane' "${PREFIX}/conf/config.yaml"; then
+            echo "Error: ${PREFIX}/conf/config.yaml does not contain 'role: data_plane'. Deployment role must be set to 'data_plane' for standalone mode."
+            echo "Please refer to the APISIX documentation for deployment modes: https://apisix.apache.org/docs/apisix/deployment-modes/"
+            exit 1
+          fi
+          if ! grep -q 'role: data_plane' "${PREFIX}/conf/config.yaml"; then
+            echo "Error: ${PREFIX}/conf/config.yaml does not contain 'role: data_plane'. Deployment role must be set to 'data_plane' for standalone mode."
+            echo "Please refer to the APISIX documentation for deployment modes: https://apisix.apache.org/docs/apisix/deployment-modes/"
+            exit 1
+          fi
+
+          if ! grep -q 'role_data_plane:' "${PREFIX}/conf/config.yaml"; then
+              echo "Error: ${PREFIX}/conf/config.yaml does not contain 'role_data_plane:'."
+              echo "Please refer to the APISIX documentation for deployment modes: https://apisix.apache.org/docs/apisix/deployment-modes/"
+              exit 1
+          fi
+
+          if ! grep -q 'config_provider: yaml' "${PREFIX}/conf/config.yaml"; then
+              echo "Error: ${PREFIX}/conf/config.yaml does not contain 'config_provider: yaml'. Config provider must be set to 'yaml' for standalone mode."
+              echo "Please refer to the APISIX documentation for deployment modes: https://apisix.apache.org/docs/apisix/deployment-modes/"
+              exit 1
+          fi
       fi
 
         if [ ! -f "${PREFIX}/conf/apisix.yaml" ]; then

--- a/redhat/docker-entrypoint.sh
+++ b/redhat/docker-entrypoint.sh
@@ -32,28 +32,7 @@ deployment:
 _EOC_
       else
           # Check if the deployment role is set to data_plane and config provider is set to yaml for standalone mode
-          if ! grep -q 'role: data_plane' "${PREFIX}/conf/config.yaml"; then
-            echo "Error: ${PREFIX}/conf/config.yaml does not contain 'role: data_plane'. Deployment role must be set to 'data_plane' for standalone mode."
-            echo "Please refer to the APISIX documentation for deployment modes: https://apisix.apache.org/docs/apisix/deployment-modes/"
-            exit 1
-          fi
-          if ! grep -q 'role: data_plane' "${PREFIX}/conf/config.yaml"; then
-            echo "Error: ${PREFIX}/conf/config.yaml does not contain 'role: data_plane'. Deployment role must be set to 'data_plane' for standalone mode."
-            echo "Please refer to the APISIX documentation for deployment modes: https://apisix.apache.org/docs/apisix/deployment-modes/"
-            exit 1
-          fi
-
-          if ! grep -q 'role_data_plane:' "${PREFIX}/conf/config.yaml"; then
-              echo "Error: ${PREFIX}/conf/config.yaml does not contain 'role_data_plane:'."
-              echo "Please refer to the APISIX documentation for deployment modes: https://apisix.apache.org/docs/apisix/deployment-modes/"
-              exit 1
-          fi
-
-          if ! grep -q 'config_provider: yaml' "${PREFIX}/conf/config.yaml"; then
-              echo "Error: ${PREFIX}/conf/config.yaml does not contain 'config_provider: yaml'. Config provider must be set to 'yaml' for standalone mode."
-              echo "Please refer to the APISIX documentation for deployment modes: https://apisix.apache.org/docs/apisix/deployment-modes/"
-              exit 1
-          fi
+          source /check_standalone_config.sh
       fi
 
         if [ ! -f "${PREFIX}/conf/apisix.yaml" ]; then

--- a/utils/check_standalone_config.sh
+++ b/utils/check_standalone_config.sh
@@ -1,0 +1,17 @@
+if ! grep -q 'role: data_plane' "${PREFIX}/conf/config.yaml"; then
+    echo "Error: ${PREFIX}/conf/config.yaml does not contain 'role: data_plane'. Deployment role must be set to 'data_plane' for standalone mode."
+    echo "Please refer to the APISIX documentation for deployment modes: https://apisix.apache.org/docs/apisix/deployment-modes/"
+    exit 1
+fi
+
+if ! grep -q 'role_data_plane:' "${PREFIX}/conf/config.yaml"; then
+    echo "Error: ${PREFIX}/conf/config.yaml does not contain 'role_data_plane:'."
+    echo "Please refer to the APISIX documentation for deployment modes: https://apisix.apache.org/docs/apisix/deployment-modes/"
+    exit 1
+fi
+
+if ! grep -q 'config_provider: yaml' "${PREFIX}/conf/config.yaml"; then
+    echo "Error: ${PREFIX}/conf/config.yaml does not contain 'config_provider: yaml'. Config provider must be set to 'yaml' for standalone mode."
+    echo "Please refer to the APISIX documentation for deployment modes: https://apisix.apache.org/docs/apisix/deployment-modes/"
+    exit 1
+fi


### PR DESCRIPTION
- Removed modification of config.yaml in standalone mode.
- Added checks to make sure it uses data plane with yaml config provider.
- Added separate config file for standalone mode example.