### PR TITLE
ci: include libyaml in image and use docker compose

### DIFF
--- a/.github/workflows/apisix-docker-example-test-standalone.yaml
+++ b/.github/workflows/apisix-docker-example-test-standalone.yaml
@@ -55,7 +55,7 @@ jobs:
         env:
           APISIX_IMAGE_TAG: ${{ format('{0}-{1}', env.APISIX_VERSION, matrix.platform) }}
           APISIX_STAND_ALONE: true
-        run: docker-compose -p docker-apisix -f example/docker-compose-standalone.yml up -d
+        run: docker compose -p docker-apisix -f example/docker-compose-standalone.yml up -d
 
       - name: Test APISIX
         run: |

--- a/.github/workflows/apisix-docker-example-test.yaml
+++ b/.github/workflows/apisix-docker-example-test.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: use docker-compose
         env:
           APISIX_IMAGE_TAG: ${{ format('{0}-{1}', env.APISIX_VERSION, matrix.platform) }}
-        run: docker-compose -p docker-apisix -f example/docker-compose.yml up -d
+        run: docker compose -p docker-apisix -f example/docker-compose.yml up -d
 
       - name: Test APISIX
         run: |

--- a/.github/workflows/apisix_dev_docker_local_test.yaml
+++ b/.github/workflows/apisix_dev_docker_local_test.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Test APISIX
         run: |
           sleep 2
-          docker logs docker-apisix_apisix_1
+          docker logs docker-apisix-apisix-1
 
           sleep 30
 

--- a/.github/workflows/apisix_dev_docker_local_test.yaml
+++ b/.github/workflows/apisix_dev_docker_local_test.yaml
@@ -42,7 +42,7 @@ jobs:
           make build-on-debian-local-dev
 
       - name: use docker-compose
-        run: docker-compose -p docker-apisix -f example/docker-compose.yml up -d
+        run: docker compose -p docker-apisix -f example/docker-compose.yml up -d
 
       - name: Test APISIX
         run: |

--- a/.github/workflows/apisix_dev_push_docker_hub.yaml
+++ b/.github/workflows/apisix_dev_push_docker_hub.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Build and run
         run: |
           make build-on-debian-dev
-          docker-compose -f ./compose/docker-compose-master.yaml up -d
+          docker compose -f ./compose/docker-compose-master.yaml up -d
           sleep 30
           docker logs compose_apisix_1
 

--- a/.github/workflows/apisix_push_docker_hub.yaml
+++ b/.github/workflows/apisix_push_docker_hub.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Build and run
         run: |
           make build-on-${{ matrix.platform }}
-          docker-compose -f ./compose/docker-compose-release.yaml up -d
+          docker compose -f ./compose/docker-compose-release.yaml up -d
           sleep 30
           docker logs compose_apisix_1
 

--- a/.github/workflows/dashboard_push_docker_hub.yaml
+++ b/.github/workflows/dashboard_push_docker_hub.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Build and run
         run: |
           make build-dashboard-${{ matrix.os }}
-          docker-compose -f ./compose/dashboard-compose.yaml up -d
+          docker compose -f ./compose/dashboard-compose.yaml up -d
           sleep 30
           docker logs compose_dashboard_1
 

--- a/all-in-one/apisix-dashboard/Dockerfile
+++ b/all-in-one/apisix-dashboard/Dockerfile
@@ -35,9 +35,18 @@ RUN set -x \
     libtool \
     pkgconfig \
     cmake \
+    make \
+    clang \
+    wget \
     git \
     openldap-dev \
     sudo \
+    && wget https://github.com/yaml/libyaml/releases/download/0.2.5/yaml-0.2.5.tar.gz \
+    && tar -zxvf yaml-0.2.5.tar.gz \
+    && cd yaml-0.2.5 \
+    && ./configure \
+    && make \
+    && make install \
     && mkdir ~/.luarocks \
     && luarocks config variables.OPENSSL_LIBDIR /usr/local/openresty/openssl/lib \
     && luarocks config variables.OPENSSL_INCDIR /usr/local/openresty/openssl/include \
@@ -46,7 +55,7 @@ RUN set -x \
     && cp -v /usr/local/apisix/deps/lib/luarocks/rocks-5.1/apisix/${APISIX_VERSION}-0/bin/apisix /usr/bin/ \
     && (if [ "$APISIX_VERSION" = "master" ] || [ "$APISIX_VERSION" \> "2.2" ]; then echo 'use shell ';else bin='#! /usr/local/openresty/luajit/bin/luajit\npackage.path = "/usr/local/apisix/?.lua;" .. package.path'; sed -i "1s@.*@$bin@" /usr/bin/apisix ; fi;) \
     && mv /usr/local/apisix/deps/share/lua/5.1/apisix /usr/local/apisix \
-    && apk del .builddeps build-base make unzip
+    && apk del .builddeps build-base make unzip clang wget
 
 # Build etcd
 FROM alpine:3.13 AS etcd-stage
@@ -116,6 +125,7 @@ WORKDIR /usr/local/apisix
 COPY --from=production-stage /usr/local/openresty/ /usr/local/openresty/
 COPY --from=production-stage /usr/local/apisix/ /usr/local/apisix/
 COPY --from=production-stage /usr/bin/apisix /usr/bin/apisix
+COPY --from=production-stage /usr/local/lib/libyaml* /usr/local/lib/
 
 COPY --from=etcd-stage /tmp/etcd/etcd /usr/bin/etcd
 COPY --from=etcd-stage /tmp/etcd/etcdctl /usr/bin/etcdctl

--- a/debian-dev/Dockerfile.local
+++ b/debian-dev/Dockerfile.local
@@ -35,6 +35,15 @@ RUN set -x \
         make \
         git  \
         sudo \
+        clang \
+        wget \
+    && wget https://github.com/yaml/libyaml/releases/download/0.2.5/yaml-0.2.5.tar.gz \
+    && tar -zxvf yaml-0.2.5.tar.gz \
+    && cd yaml-0.2.5 \
+    && ./configure \
+    && make \
+    && make install \
+    && cd /apisix \
     && ls -al \
     && make deps \
     && mkdir -p ${ENV_INST_LUADIR} \
@@ -49,6 +58,7 @@ ARG INSTALL_BROTLI=./install-brotli.sh
 COPY --from=build /usr/local/apisix /usr/local/apisix
 COPY --from=build /usr/local/openresty /usr/local/openresty
 COPY --from=build /usr/bin/apisix /usr/bin/apisix
+COPY --from=build /usr/local/lib/libyaml* /usr/local/lib/
 
 COPY ${INSTALL_BROTLI} /install-brotli.sh
 RUN chmod +x /install-brotli.sh \  

--- a/debian-dev/Dockerfile.local
+++ b/debian-dev/Dockerfile.local
@@ -35,15 +35,7 @@ RUN set -x \
         make \
         git  \
         sudo \
-        clang \
-        wget \
-    && wget https://github.com/yaml/libyaml/releases/download/0.2.5/yaml-0.2.5.tar.gz \
-    && tar -zxvf yaml-0.2.5.tar.gz \
-    && cd yaml-0.2.5 \
-    && ./configure \
-    && make \
-    && make install \
-    && cd /apisix \
+        libyaml-dev \
     && ls -al \
     && make deps \
     && mkdir -p ${ENV_INST_LUADIR} \
@@ -58,7 +50,7 @@ ARG INSTALL_BROTLI=./install-brotli.sh
 COPY --from=build /usr/local/apisix /usr/local/apisix
 COPY --from=build /usr/local/openresty /usr/local/openresty
 COPY --from=build /usr/bin/apisix /usr/bin/apisix
-COPY --from=build /usr/local/lib/libyaml* /usr/local/lib/
+COPY --from=build /usr/lib/x86_64-linux-gnu/libyaml* /usr/local/lib/
 
 COPY ${INSTALL_BROTLI} /install-brotli.sh
 RUN chmod +x /install-brotli.sh \  


### PR DESCRIPTION
This pull request includes updates to the CI workflow to address build issues.

### Changes
1. **Build libyaml before installing lyaml**:
   - Added a step to build and install libyaml before attempting to install the lyaml Lua module.
   - This change resolves the issue where lyaml installation fails due to missing libyaml symbols.

2. **Switch from docker-compose to docker compose**:
   - Updated the CI workflow to replace `docker-compose` with `docker compose` for compatibility with newer Docker versions.