### PR TITLE
Update Dockerfile for Debian with consisten apt-get use and bump default apisix version

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -17,11 +17,11 @@
 
 FROM debian:bullseye-slim
 
-ARG APISIX_VERSION=3.9.0
+ARG APISIX_VERSION=3.10.0
 
 RUN set -ex; \
     arch=$(dpkg --print-architecture); \
-    apt update; \
+    apt-get update; \
     apt-get -y install --no-install-recommends wget gnupg ca-certificates curl;\
     codename=`grep -Po 'VERSION="[0-9]+ \(\K[^)]+' /etc/os-release`; \
     case "${arch}" in \
@@ -34,8 +34,8 @@ RUN set -ex; \
         && echo "deb https://repos.apiseven.com/packages/arm64/debian $codename main" | tee /etc/apt/sources.list.d/apisix.list \
         ;; \
     esac; \
-    apt update \
-    && apt install -y apisix=${APISIX_VERSION}-0 \
+    apt-get update \
+    && apt-get install -y apisix=${APISIX_VERSION}-0 \
     && apt-get purge -y --auto-remove \
     && rm /usr/local/openresty/bin/etcdctl \
     && openresty -V \


### PR DESCRIPTION
This PR is updating two things in Dockerfile for debian build:

- replaces `apt` commands with `apt-get` equivalents to have consistent use of package manager
- updates default apisix version installation to 3.10.0 as this is latest one