### PR TITLE
fix: container name in release workflow

### DIFF
--- a/.github/workflows/apisix_push_docker_hub.yaml
+++ b/.github/workflows/apisix_push_docker_hub.yaml
@@ -24,7 +24,7 @@ jobs:
           make build-on-${{ matrix.platform }}
           docker compose -f ./compose/docker-compose-release.yaml up -d
           sleep 30
-          docker logs compose_apisix_1
+          docker logs compose-apisix-1
 
       - name: Test route
         run: |


### PR DESCRIPTION
The correct name of apisix container is here: https://github.com/apache/apisix-docker/actions/runs/10676375173/job/29589821558#step:3:1542.

The newer version of docker compose uses hyphens as delimiters instead of underscores.