### PR TITLE
fix: use hyphens as delimiter instead of underscore

### DIFF
--- a/.github/workflows/apisix_dev_push_docker_hub.yaml
+++ b/.github/workflows/apisix_dev_push_docker_hub.yaml
@@ -28,7 +28,7 @@ jobs:
           make build-on-debian-dev
           docker compose -f ./compose/docker-compose-master.yaml up -d
           sleep 30
-          docker logs compose_apisix_1
+          docker logs compose-apisix-1
 
       - name: Test APISIX
         run: |

--- a/.github/workflows/dashboard_push_docker_hub.yaml
+++ b/.github/workflows/dashboard_push_docker_hub.yaml
@@ -25,7 +25,7 @@ jobs:
           make build-dashboard-${{ matrix.os }}
           docker compose -f ./compose/dashboard-compose.yaml up -d
           sleep 30
-          docker logs compose_dashboard_1
+          docker logs compose-dashboard-1
 
       - name: check
         run: |


### PR DESCRIPTION
Same as: https://github.com/apache/apisix-docker/pull/568.