### PR TITLE
chore: upgrade actions/upload-artifact

### DIFF
--- a/.github/workflows/dashboard_push_docker_hub.yaml
+++ b/.github/workflows/dashboard_push_docker_hub.yaml
@@ -38,7 +38,7 @@ jobs:
           make save-dashboard-${{ matrix.os }}-tar
 
       - name: Upload Image
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           path: ./package
 


### PR DESCRIPTION
Starting January 30th, 2025, GitHub Actions customers will no longer be able to use v3 of actions/upload-artifact or actions/download-artifact. Customers should update workflows to begin using v4 of the artifact actions as soon as possible. 