### PR TITLE
fix: failing docker build for debian-dev

### DIFF
--- a/debian-dev/Dockerfile
+++ b/debian-dev/Dockerfile
@@ -65,7 +65,7 @@ ENV PATH=$PATH:/usr/local/openresty/luajit/bin:/usr/local/openresty/nginx/sbin:/
 EXPOSE 9080 9443
 
 COPY ./docker-entrypoint.sh /docker-entrypoint.sh
-COPY ./utils/check_standalone_config.sh /check_standalone_config.sh
+COPY ./check_standalone_config.sh /check_standalone_config.sh
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 


### PR DESCRIPTION
Introduced bug in this PR https://github.com/apache/apisix-docker/commit/3ec55476d853c27c8aed4b7766690f55019f65db#diff-022bec4181153c0bb2d82183d8e70d9180a913a44c10a2509fe3be3a59170504
