### PR TITLE
fix: failing build due to missing runtime dependency

### DIFF
--- a/debian-dev/Dockerfile
+++ b/debian-dev/Dockerfile
@@ -45,6 +45,11 @@ RUN set -x \
 
 FROM api7/apisix-runtime:dev AS production-stage
 
+# Install the runtime libyaml package
+RUN apt-get -y update --fix-missing \
+    && apt-get install -y libldap2-dev libyaml-0-2 \
+    && apt-get remove --purge --auto-remove -y
+
 COPY --from=build /usr/local/apisix /usr/local/apisix
 COPY --from=build /usr/bin/apisix /usr/bin/apisix
 

--- a/debian-dev/Dockerfile
+++ b/debian-dev/Dockerfile
@@ -65,7 +65,7 @@ ENV PATH=$PATH:/usr/local/openresty/luajit/bin:/usr/local/openresty/nginx/sbin:/
 EXPOSE 9080 9443
 
 COPY ./docker-entrypoint.sh /docker-entrypoint.sh
-COPY ./utils/check_standalone_config.sh /check_standalone_config.sh
+COPY ./check_standalone_config.sh /check_standalone_config.sh
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 


### PR DESCRIPTION
After fix, can confirm the fix locally
<img width="1496" alt="Screenshot 2025-02-24 at 3 02 23 PM" src="https://github.com/user-attachments/assets/d13f7b49-3d17-4c5e-9366-002378596d5b" />
