### PR TITLE
Fix: APISIX Dashboard "etcd not connected" issue in Docker Compose setup

### DIFF
--- a/example/dashboard_conf/conf.yaml
+++ b/example/dashboard_conf/conf.yaml
@@ -1,0 +1,95 @@
+conf:
+  listen:
+    host: 0.0.0.0     # `manager api` listening ip or host name
+    port: 9000          # `manager api` listening port
+  allow_list:           # If we don't set any IP list, then any IP access is allowed by default.
+    - 0.0.0.0/0
+  etcd:
+    endpoints:          # supports defining multiple etcd host addresses for an etcd cluster
+      - "http://etcd:2379"
+                          # yamllint disable rule:comments-indentation
+                          # etcd basic auth info
+    # username: "root"    # ignore etcd username if not enable etcd auth
+    # password: "123456"  # ignore etcd password if not enable etcd auth
+    mtls:
+      key_file: ""          # Path of your self-signed client side key
+      cert_file: ""         # Path of your self-signed client side cert
+      ca_file: ""           # Path of your self-signed ca cert, the CA is used to sign callers' certificates
+    # prefix: /apisix     # apisix config's prefix in etcd, /apisix by default
+  log:
+    error_log:
+      level: warn       # supports levels, lower to higher: debug, info, warn, error, panic, fatal
+      file_path:
+        logs/error.log  # supports relative path, absolute path, standard output
+                        # such as: logs/error.log, /tmp/logs/error.log, /dev/stdout, /dev/stderr
+    access_log:
+      file_path:
+        logs/access.log  # supports relative path, absolute path, standard output
+                         # such as: logs/access.log, /tmp/logs/access.log, /dev/stdout, /dev/stderr
+                         # log example: 2020-12-09T16:38:09.039+0800	INFO	filter/logging.go:46	/apisix/admin/routes/r1	{"status": 401, "host": "127.0.0.1:9000", "query": "asdfsafd=adf&a=a", "requestId": "3d50ecb8-758c-46d1-af5b-cd9d1c820156", "latency": 0, "remoteIP": "127.0.0.1", "method": "PUT", "errs": []}
+  security:
+      # access_control_allow_origin: "http://httpbin.org"
+      # access_control_allow_credentials: true          # support using custom cors configration
+      # access_control_allow_headers: "Authorization"
+      # access_control-allow_methods: "*"
+      # x_frame_options: "deny"
+      content_security_policy: "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; frame-src *"  # You can set frame-src to provide content for your grafana panel.
+
+authentication:
+  secret:
+    secret              # secret for jwt token generation.
+                        # NOTE: Highly recommended to modify this value to protect `manager api`.
+                        # if it's default value, when `manager api` start, it will generate a random string to replace it.
+  expire_time: 3600     # jwt token expire time, in second
+  users:                # yamllint enable rule:comments-indentation
+    - username: admin   # username and password for login `manager api`
+      password: admin
+    - username: user
+      password: user
+
+plugins:                          # plugin list (sorted in alphabetical order)
+  - api-breaker
+  - authz-keycloak
+  - basic-auth
+  - batch-requests
+  - consumer-restriction
+  - cors
+  # - dubbo-proxy
+  - echo
+  # - error-log-logger
+  # - example-plugin
+  - fault-injection
+  - grpc-transcode
+  - hmac-auth
+  - http-logger
+  - ip-restriction
+  - jwt-auth
+  - kafka-logger
+  - key-auth
+  - limit-conn
+  - limit-count
+  - limit-req
+  # - log-rotate
+  # - node-status
+  - openid-connect
+  - prometheus
+  - proxy-cache
+  - proxy-mirror
+  - proxy-rewrite
+  - redirect
+  - referer-restriction
+  - request-id
+  - request-validation
+  - response-rewrite
+  - serverless-post-function
+  - serverless-pre-function
+  # - skywalking
+  - sls-logger
+  - syslog
+  - tcp-logger
+  - udp-logger
+  - uri-blocker
+  - wolf-rbac
+  - zipkin
+  - server-info
+  - traffic-split

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -18,6 +18,16 @@
 version: "3"
 
 services:
+  apisix-dashboard:
+    image: apache/apisix-dashboard:3.0.0-alpine
+    restart: always
+    volumes:
+    - ./dashboard_conf/conf.yaml:/usr/local/apisix-dashboard/conf/conf.yaml
+    ports:
+    - "9000:9000"
+    networks:
+      apisix:
+      
   apisix:
     image: apache/apisix:${APISIX_IMAGE_TAG:-3.12.0-debian}
     restart: always


### PR DESCRIPTION
### **Description:**  
This pull request enhances the APISIX Docker setup by introducing the APISIX Dashboard for easier management and visualization. The following key changes were made:
### 
**- Added `example/dashboard_conf/conf.yaml`**  
  A new configuration file for the APISIX Dashboard has been created. This file includes the necessary settings to connect to the etcd instance and manage APISIX through a web interface.

**### - Updated `docker-compose.yml`**  
  A new service named `apisix-dashboard` has been added to the Docker Compose configuration. This service runs the APISIX Dashboard and is configured to connect to the existing `etcd` instance on `etcd:2379`.

**### - etcd Connection Fix**  
  The configuration ensures the dashboard connects to etcd correctly using the internal Docker network.