### PR TITLE
Use named context for check_standalong_config.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,18 +75,14 @@ endef
 .PHONY: build-on-redhat
 build-on-redhat:
 	@$(call func_echo_status, "$@ -> [ Start ]")
-	cp ./utils/check_standalone_config.sh redhat/check_standalone_config.sh
-	$(ENV_DOCKER) build -t $(ENV_APISIX_IMAGE_TAG_NAME)-redhat -f ./redhat/Dockerfile redhat
-	rm -f redhat/check_standalone_config.sh
+	$(ENV_DOCKER) build -t $(ENV_APISIX_IMAGE_TAG_NAME)-redhat -f ./redhat/Dockerfile --build-context utils=./utils redhat
 	@$(call func_echo_success_status, "$@ -> [ Done ]")
 
 ### build-on-debian-dev : Build apache/apisix:xx-debian-dev image
 .PHONY: build-on-debian-dev
 build-on-debian-dev:
 	@$(call func_echo_status, "$@ -> [ Start ]")
-	cp ./utils/check_standalone_config.sh debian-dev/check_standalone_config.sh
-	$(ENV_DOCKER) build -t $(ENV_APISIX_IMAGE_TAG_NAME)-debian-dev -f ./debian-dev/Dockerfile debian-dev
-	rm -f debian-dev/check_standalone_config.sh
+	$(ENV_DOCKER) build -t $(ENV_APISIX_IMAGE_TAG_NAME)-debian-dev -f ./debian-dev/Dockerfile --build-context utils=./utils debian-dev
 	@$(call func_echo_success_status, "$@ -> [ Done ]")
 
 ### build-on-debian-local-dev : Build apache/apisix:xx-debian-dev image
@@ -107,9 +103,7 @@ endif
 .PHONY: build-on-debian
 build-on-debian:
 	@$(call func_echo_status, "$@ -> [ Start ]")
-	cp ./utils/check_standalone_config.sh debian/check_standalone_config.sh
-	$(ENV_DOCKER) build -t $(ENV_APISIX_IMAGE_TAG_NAME)-debian -f ./debian/Dockerfile debian
-	rm -f debian/check_standalone_config.sh
+	$(ENV_DOCKER) build -t $(ENV_APISIX_IMAGE_TAG_NAME)-debian -f ./debian/Dockerfile --build-context utils=./utils debian
 	@$(call func_echo_success_status, "$@ -> [ Done ]")
 
 
@@ -117,12 +111,12 @@ build-on-debian:
 .PHONY: push-multiarch-dev-on-debian
 push-multiarch-dev-on-debian:
 	@$(call func_echo_status, "$@ -> [ Start ]")
-	cp ./utils/check_standalone_config.sh debian-dev/check_standalone_config.sh
 	$(ENV_DOCKER) buildx build --network=host --push \
 		-t $(IMAGE_NAME):dev \
 		--platform linux/amd64,linux/arm64 \
-		-f ./debian-dev/Dockerfile debian-dev
-	rm -f debian-dev/check_standalone_config.sh
+		-f ./debian-dev/Dockerfile \
+		--build-context utils=./utils \
+		debian-dev
 	@$(call func_echo_success_status, "$@ -> [ Done ]")
 
 
@@ -130,12 +124,12 @@ push-multiarch-dev-on-debian:
 .PHONY: push-multiarch-on-debian
 push-multiarch-on-debian:
 	@$(call func_echo_status, "$@ -> [ Start ]")
-	cp ./utils/check_standalone_config.sh debian/check_standalone_config.sh
 	$(ENV_DOCKER) buildx build --network=host --push \
 		-t $(ENV_APISIX_IMAGE_TAG_NAME)-debian \
 		--platform linux/amd64,linux/arm64 \
-		-f ./debian/Dockerfile debian
-	rm -f debian/check_standalone_config.sh
+		-f ./debian/Dockerfile \
+		--build-context utils=./utils \
+		debian
 	@$(call func_echo_success_status, "$@ -> [ Done ]")
 
 
@@ -143,12 +137,12 @@ push-multiarch-on-debian:
 .PHONY: push-multiarch-on-redhat
 push-multiarch-on-redhat:
 	@$(call func_echo_status, "$@ -> [ Start ]")
-	cp ./utils/check_standalone_config.sh redhat/check_standalone_config.sh
 	$(ENV_DOCKER) buildx build --network=host --push \
 		-t $(ENV_APISIX_IMAGE_TAG_NAME)-redhat \
 		--platform linux/amd64,linux/arm64 \
-		-f ./redhat/Dockerfile redhat
-	rm -f redhat/check_standalone_config.sh
+		-f ./redhat/Dockerfile \
+		--build-context utils=./utils \
+		redhat
 	@$(call func_echo_success_status, "$@ -> [ Done ]")
 
 ### push-multiarch-on-latest : Push apache/apisix:latest image
@@ -159,12 +153,12 @@ push-multiarch-on-redhat:
 push-multiarch-on-latest:
 	@$(call func_echo_status, "$@ -> [ Start ]")
 	@if [ "$(shell echo "$(APISIX_VERSION) $(MAX_APISIX_VERSION)" | tr " " "\n" | sort -rV | head -n 1)" == "$(APISIX_VERSION)" ]; then \
-		cp ./utils/check_standalone_config.sh debian/check_standalone_config.sh; \
 		$(ENV_DOCKER) buildx build --network=host --push \
 			-t $(IMAGE_NAME):latest \
 			--platform linux/amd64,linux/arm64 \
-			-f ./debian/Dockerfile debian; \
-		rm -f debian/check_standalone_config.sh; \
+			-f ./debian/Dockerfile \
+			--build-context utils=./utils
+			debian; \
 	fi
 	@$(call func_echo_success_status, "$@ -> [ Done ]")
 

--- a/debian-dev/Dockerfile
+++ b/debian-dev/Dockerfile
@@ -60,7 +60,7 @@ RUN apt-get -y update --fix-missing \
     && apt-get remove --purge --auto-remove -y
 
 COPY ./install-brotli.sh /install-brotli.sh
-RUN chmod +x /install-brotli.sh \  
+RUN chmod +x /install-brotli.sh \
     && cd / && ./install-brotli.sh && rm -rf /install-brotli.sh
 
 WORKDIR /usr/local/apisix
@@ -70,7 +70,7 @@ ENV PATH=$PATH:/usr/local/openresty/luajit/bin:/usr/local/openresty/nginx/sbin:/
 EXPOSE 9080 9443
 
 COPY ./docker-entrypoint.sh /docker-entrypoint.sh
-COPY ./check_standalone_config.sh /check_standalone_config.sh
+COPY --from=utils ./check_standalone_config.sh /check_standalone_config.sh
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -42,7 +42,7 @@ RUN set -ex; \
     && apisix version
 
 COPY ./install-brotli.sh /install-brotli.sh
-RUN chmod +x /install-brotli.sh \  
+RUN chmod +x /install-brotli.sh \
     && cd / && ./install-brotli.sh && rm -rf /install-brotli.sh
 
 RUN apt-get -y purge --auto-remove curl wget gnupg --allow-remove-essential
@@ -64,7 +64,7 @@ RUN ln -sf /dev/stdout /usr/local/apisix/logs/access.log \
 EXPOSE 9080 9443
 
 COPY ./docker-entrypoint.sh /docker-entrypoint.sh
-COPY ./check_standalone_config.sh /check_standalone_config.sh
+COPY --from=utils ./check_standalone_config.sh /check_standalone_config.sh
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 

--- a/redhat/Dockerfile
+++ b/redhat/Dockerfile
@@ -43,7 +43,7 @@ RUN ln -sf /dev/stdout /usr/local/apisix/logs/access.log \
 EXPOSE 9080 9443
 
 COPY ./docker-entrypoint.sh /docker-entrypoint.sh
-COPY ./check_standalone_config.sh /check_standalone_config.sh
+COPY --from=utils ./check_standalone_config.sh /check_standalone_config.sh
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 


### PR DESCRIPTION
[This commit](https://github.com/apache/apisix-docker/commit/3ec55476d853c27c8aed4b7766690f55019f65db) added a step to the build process to copy the `utils/check_standalone_config.sh` file into the targeted Docker project before being able to build the image. This is a well-meaning approach to reduce code duplication and ease maintenance. However, the problem with this approach is that it breaks the ability to use this repo as a remote Docker context as the Dockerfiles now include a `COPY` command for a file that does not exist in GitHub.
The better way to handle this is to use named context to source the file from `./utils`. This PR updates the Dockerfile definitions and the Makefile build steps.
With this change, anyone can now build images from my branch like this:
```
docker build -t apisix --build-context utils=https://github.com/qswinson/apisix-docker.git#docker-named-context:utils https://github.com/qswinson/apisix-docker.git#docker-named-context:debian
```

You can also define a [Docker Bake](https://docs.docker.com/build/bake/) file in your own repo to customize the final APISIX image. Name the file with the contents below`docker-bake.hcl` and build it with this command: `docker buildx bake apisix`.
```
target base {
  context = "https://github.com/qswinson/apisix-docker.git#docker-named-context:debian"
  contexts = {
    "utils" = "https://github.com/qswinson/apisix-docker.git#docker-named-context:utils"
  }
  platforms = [
    "linux/amd64"
  ]
}

target apisix {
  contexts = {
    baseapisix = "target:base"
  }
  dockerfile = "Dockerfile"
  tags = ["apisix:latest"]
  platforms = [
    "linux/x86_64"
  ]
}
```

Being able to build images on demand is very important for addressing security vulnerabilities that are resolved in the base debian/redhat image.