### PR TITLE
Update nginx images to version 1.19.10-alpine

### DIFF
--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -51,7 +51,7 @@ services:
       apisix:
 
   web1:
-    image: nginx:1.19.0-alpine
+    image: nginx:1.19.10-alpine
     restart: always
     volumes:
       - ./upstream/web1.conf:/etc/nginx/nginx.conf
@@ -63,7 +63,7 @@ services:
       apisix:
 
   web2:
-    image: nginx:1.19.0-alpine
+    image: nginx:1.19.10-alpine
     restart: always
     volumes:
       - ./upstream/web2.conf:/etc/nginx/nginx.conf


### PR DESCRIPTION
1.19.0 uses a deprecated image manifest version 2, schema 1 which has been deprecated.