### PR TITLE
Fix image name in etcd container example

### DIFF
--- a/docs/en/latest/manual.md
+++ b/docs/en/latest/manual.md
@@ -45,7 +45,7 @@ docker run -it --name etcd-server \
 -p 2380:2380  \
 --network apisix \
 --ip 172.18.5.10 \
---env ALLOW_NONE_AUTHENTICATION=yes bitnami/etcd:3.4.9
+--env ALLOW_NONE_AUTHENTICATION=yes bitnamilegacy/etcd:3.4.9
 ```
 
 > Note:


### PR DESCRIPTION
bitnami:etcd is no longer been use. Need to update to bitnamilegacy in order to resolve image not found when copy pasting the command to pull the image