### PR TITLE
chore: optimize debian-dev Dockerfiles for better layer caching

### DIFF
--- a/debian-dev/Dockerfile
+++ b/debian-dev/Dockerfile
@@ -19,8 +19,11 @@ FROM api7/apisix-runtime:dev AS build
 
 ARG ENABLE_PROXY=false
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
+ARG INSTALL_BROTLI=./install-brotli.sh
+
+# Install build dependencies
 RUN set -x \
     && (test "${ENABLE_PROXY}" != "true" || /bin/sed -i 's,http://deb.debian.org,https://mirrors.aliyun.com,g' /etc/apt/sources.list) \
     && apt-get -y update --fix-missing \
@@ -35,13 +38,19 @@ RUN set -x \
         unzip \
         wget \
         libyaml-dev \
-    && curl https://raw.githubusercontent.com/apache/apisix/master/utils/linux-install-luarocks.sh -sL | bash - \
+        cmake
+
+# Install luarocks and apisix
+RUN curl https://raw.githubusercontent.com/apache/apisix/master/utils/linux-install-luarocks.sh -sL | bash - \
     && luarocks install https://raw.githubusercontent.com/apache/apisix/master/apisix-master-0.rockspec --tree=/usr/local/apisix/deps PCRE_DIR=/usr/local/openresty/pcre \
     && cp -v /usr/local/apisix/deps/lib/luarocks/rocks-5.1/apisix/master-0/bin/apisix /usr/bin/ \
     && mv /usr/local/apisix/deps/share/lua/5.1/apisix /usr/local/apisix \
     # forward request and error logs to docker log collector
     && ln -sf /dev/stdout /usr/local/apisix/logs/access.log \
     && ln -sf /dev/stderr /usr/local/apisix/logs/error.log
+
+COPY ${INSTALL_BROTLI} /install-brotli.sh
+RUN chmod +x /install-brotli.sh && /install-brotli.sh
 
 FROM api7/apisix-runtime:dev AS production-stage
 
@@ -52,16 +61,11 @@ RUN apt-get -y update --fix-missing \
 
 COPY --from=build /usr/local/apisix /usr/local/apisix
 COPY --from=build /usr/bin/apisix /usr/bin/apisix
+COPY --from=build /usr/local/brotli /usr/local/brotli
 
-ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get -y update --fix-missing \
-    && apt-get install -y \
-        libldap2-dev \
-    && apt-get remove --purge --auto-remove -y
-
-COPY ./install-brotli.sh /install-brotli.sh
-RUN chmod +x /install-brotli.sh \  
-    && cd / && ./install-brotli.sh && rm -rf /install-brotli.sh
+RUN echo /usr/local/brotli/lib | tee /etc/ld.so.conf.d/brotli.conf \
+    && ldconfig \
+    && ln -sf /usr/local/brotli/bin/brotli /usr/bin/brotli
 
 WORKDIR /usr/local/apisix
 
@@ -71,10 +75,10 @@ EXPOSE 9080 9443
 
 COPY ./docker-entrypoint.sh /docker-entrypoint.sh
 COPY ./check_standalone_config.sh /check_standalone_config.sh
+RUN chmod +x /docker-entrypoint.sh /check_standalone_config.sh
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
 CMD ["docker-start"]
-
 
 STOPSIGNAL SIGQUIT

--- a/debian-dev/Dockerfile.local
+++ b/debian-dev/Dockerfile.local
@@ -14,20 +14,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-# Use this dockerfile to create a docker image of your apisix local/patched codebase
-
 FROM debian:bullseye-slim AS build
 
 ARG ENABLE_PROXY=false
 ARG CODE_PATH
 
-ENV DEBIAN_FRONTEND noninteractive
-ENV ENV_INST_LUADIR /usr/local/apisix
-
-COPY ${CODE_PATH} /apisix
+ENV DEBIAN_FRONTEND=noninteractive
+ENV ENV_INST_LUADIR=/usr/local/apisix
 
 WORKDIR /apisix
+
+ARG INSTALL_BROTLI=./install-brotli.sh
 
 RUN set -x \
     && apt-get -y update --fix-missing \
@@ -36,25 +33,44 @@ RUN set -x \
         git  \
         sudo \
         libyaml-dev \
-    && ls -al \
-    && make deps \
+        cmake \
+        wget \
+        unzip
+
+COPY ${CODE_PATH}/Makefile ${CODE_PATH}/apisix-master-0.rockspec ${CODE_PATH}/.requirements /apisix/
+COPY ${CODE_PATH}/utils/install-dependencies.sh /apisix/utils/
+
+RUN make deps \
     && mkdir -p ${ENV_INST_LUADIR} \
-    && cp -r deps ${ENV_INST_LUADIR} \
-    && make install
+    && cp -r deps ${ENV_INST_LUADIR}
+
+COPY ${INSTALL_BROTLI} /install-brotli.sh
+RUN chmod +x /install-brotli.sh && /install-brotli.sh
+
+COPY ${CODE_PATH} /apisix
+
+RUN make install
 
 FROM debian:bullseye-slim
 
 ARG ENTRYPOINT_PATH=./docker-entrypoint.sh
-ARG INSTALL_BROTLI=./install-brotli.sh
+ARG CHECK_STANDALONE_CONFIG=./check_standalone_config.sh
+
+# Install the runtime libyaml package
+RUN apt-get -y update --fix-missing \
+    && apt-get install -y libldap2-dev libyaml-0-2 \
+    && apt-get remove --purge --auto-remove -y \
+    && mkdir -p /usr/local/apisix/ui
 
 COPY --from=build /usr/local/apisix /usr/local/apisix
 COPY --from=build /usr/local/openresty /usr/local/openresty
 COPY --from=build /usr/bin/apisix /usr/bin/apisix
-COPY --from=build /usr/lib/x86_64-linux-gnu/libyaml* /usr/local/lib/
+COPY --from=build /usr/local/brotli /usr/local/brotli
+COPY --chown=nobody:root ui/ /usr/local/apisix/ui/
 
-COPY ${INSTALL_BROTLI} /install-brotli.sh
-RUN chmod +x /install-brotli.sh \  
-    && cd / && ./install-brotli.sh && rm -rf /install-brotli.sh
+RUN echo /usr/local/brotli/lib | tee /etc/ld.so.conf.d/brotli.conf \
+    && ldconfig \
+    && ln -sf /usr/local/brotli/bin/brotli /usr/bin/brotli
 
 ENV PATH=$PATH:/usr/local/openresty/luajit/bin:/usr/local/openresty/nginx/sbin:/usr/local/openresty/bin
 
@@ -66,7 +82,8 @@ RUN ln -sf /dev/stdout /usr/local/apisix/logs/access.log \
 EXPOSE 9080 9443
 
 COPY ${ENTRYPOINT_PATH} /docker-entrypoint.sh
-COPY ../utils/check_standalone_config.sh /check_standalone_config.sh
+COPY ${CHECK_STANDALONE_CONFIG} /check_standalone_config.sh
+RUN chmod +x /docker-entrypoint.sh /check_standalone_config.sh
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 


### PR DESCRIPTION
# Summary
- Optimize debian-dev/Dockerfile and debian-dev/Dockerfile.local for better Docker layer caching
- Copy only dependency-related files before full source code to improve cache hits on code changes

# Changes
## Layer Caching Optimization
- Dockerfile.local: Separate COPY steps - first copy Makefile, rockspec, .requirements, then run make deps, finally copy remaining source code
- This ensures make deps layer is cached when only application code changes

## Brotli Build Improvement
- Move brotli compilation into Dockerfile as separate RUN layer (cached independently)
- Copy pre-built brotli from build stage instead of rebuilding in production stage

## Cleanup
- Remove duplicate apt-get install libldap2-dev in production stage
- Fix ENV syntax (DEBIAN_FRONTEND=noninteractive instead of DEBIAN_FRONTEND noninteractive)

## Benefits
- Faster rebuilds: Code-only changes no longer trigger full dependency reinstallation
- Smaller final image: Brotli build tools not installed in production stage
- Simpler maintenance: No external shell script dependency