### PR TITLE
APISIX and APISIX-ingress containers to work without anyuid SCC

### DIFF
--- a/debian-dev/Dockerfile
+++ b/debian-dev/Dockerfile
@@ -67,6 +67,14 @@ WORKDIR /usr/local/apisix
 
 ENV PATH=$PATH:/usr/local/openresty/luajit/bin:/usr/local/openresty/nginx/sbin:/usr/local/openresty/bin
 
+RUN groupadd --system --gid 636 apisix \
+    && useradd --system --gid apisix --no-create-home --shell /usr/sbin/nologin --uid 636 apisix \
+    && chown -R apisix:apisix /usr/local/apisix \
+    && chgrp -R 0 /usr/local/apisix \
+    && chmod -R g=u /usr/local/apisix
+
+USER apisix
+
 EXPOSE 9080 9443
 
 COPY ./docker-entrypoint.sh /docker-entrypoint.sh

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -53,7 +53,9 @@ ENV PATH=$PATH:/usr/local/openresty/luajit/bin:/usr/local/openresty/nginx/sbin:/
 
 RUN groupadd --system --gid 636 apisix \
     && useradd --system --gid apisix --no-create-home --shell /usr/sbin/nologin --uid 636 apisix \
-    && chown -R apisix:apisix /usr/local/apisix
+    && chown -R apisix:apisix /usr/local/apisix \
+    && chgrp -R 0 /usr/local/apisix \
+    && chmod -R g=u /usr/local/apisix
 
 USER apisix
 


### PR DESCRIPTION
This pull request improves the security and consistency of the Docker images by updating user and group permissions for the `apisix` directory in both the `debian` and `debian-dev` Dockerfiles.

 The main changes ensure that the container runs as a non-root user and that directory permissions are set appropriately for group access.

**Dockerfile permission and user management updates:**

* Added commands to change the group ownership of `/usr/local/apisix` to group ID 0 and set group permissions to match user permissions, improving compatibility with OpenShift and similar environments (`debian/Dockerfile`, `debian-dev/Dockerfile`). [[1]](diffhunk://#diff-b98298742c5536fa90710aea60f865cdf0149b61c06288c4a0219ce4796ec807L56-R58) [[2]](diffhunk://#diff-b70eb0e8d74ce081444b7b2a89316c356f1aea9396d5e5604a6129d74bccbb7eR70-R77)
* In `debian-dev/Dockerfile`, explicitly added creation of the `apisix` system group and user, set ownership and permissions for `/usr/local/apisix`, and switched to running the container as the `apisix` user.

This PR closes #611 