### PR TITLE
fix: Fixed Dockerfiles to be able to run in Openshift without anyuid

### DIFF
--- a/debian-dev/Dockerfile
+++ b/debian-dev/Dockerfile
@@ -53,6 +53,9 @@ RUN apt-get -y update --fix-missing \
 COPY --from=build /usr/local/apisix /usr/local/apisix
 COPY --from=build /usr/bin/apisix /usr/bin/apisix
 
+RUN chgrp -R 0 /usr/local/apisix \
+    && chmod -R g=u /usr/local/apisix
+
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get -y update --fix-missing \
     && apt-get install -y \

--- a/debian-dev/Dockerfile
+++ b/debian-dev/Dockerfile
@@ -53,9 +53,6 @@ RUN apt-get -y update --fix-missing \
 COPY --from=build /usr/local/apisix /usr/local/apisix
 COPY --from=build /usr/bin/apisix /usr/bin/apisix
 
-RUN chgrp -R 0 /usr/local/apisix \
-    && chmod -R g=u /usr/local/apisix
-
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get -y update --fix-missing \
     && apt-get install -y \

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -53,7 +53,7 @@ ENV PATH=$PATH:/usr/local/openresty/luajit/bin:/usr/local/openresty/nginx/sbin:/
 
 RUN groupadd --system --gid 636 apisix \
     && useradd --system --gid apisix --no-create-home --shell /usr/sbin/nologin --uid 636 apisix \
-    && chown -R apisix:apisix /usr/local/apisix \
+    && chown -R apisix:0 /usr/local/apisix \
     && chgrp -R 0 /usr/local/apisix \
     && chmod -R g=u /usr/local/apisix
 

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -54,7 +54,6 @@ ENV PATH=$PATH:/usr/local/openresty/luajit/bin:/usr/local/openresty/nginx/sbin:/
 RUN groupadd --system --gid 636 apisix \
     && useradd --system --gid apisix --no-create-home --shell /usr/sbin/nologin --uid 636 apisix \
     && chown -R apisix:0 /usr/local/apisix \
-    && chgrp -R 0 /usr/local/apisix \
     && chmod -R g=u /usr/local/apisix
 
 USER apisix

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -53,7 +53,9 @@ ENV PATH=$PATH:/usr/local/openresty/luajit/bin:/usr/local/openresty/nginx/sbin:/
 
 RUN groupadd --system --gid 636 apisix \
     && useradd --system --gid apisix --no-create-home --shell /usr/sbin/nologin --uid 636 apisix \
-    && chown -R apisix:apisix /usr/local/apisix
+    && chown -R apisix:apisix /usr/local/apisix \
+    && chgrp -R 0 /usr/local/apisix \
+    && chmod -R g=u /usr/local/apisix
 
 USER apisix
 

--- a/redhat/Dockerfile
+++ b/redhat/Dockerfile
@@ -35,13 +35,18 @@ WORKDIR /usr/local/apisix
 
 ENV PATH=$PATH:/usr/local/openresty/luajit/bin:/usr/local/openresty/nginx/sbin:/usr/local/openresty/bin
 
-RUN chgrp -R 0 /usr/local/apisix \
+RUN groupadd --system --gid 636 apisix \
+    && useradd --system --gid apisix --no-create-home --shell /usr/sbin/nologin --uid 636 apisix \
+    && chown -R apisix:apisix /usr/local/apisix \
+    && chgrp -R 0 /usr/local/apisix \
     && chmod -R g=u /usr/local/apisix
 
 # forward request and error logs to docker log collector
 RUN ln -sf /dev/stdout /usr/local/apisix/logs/access.log \
     && ln -sf /dev/stderr /usr/local/apisix/logs/error.log \
     && rm /usr/local/openresty/bin/etcdctl
+
+USER apisix
 
 EXPOSE 9080 9443
 

--- a/redhat/Dockerfile
+++ b/redhat/Dockerfile
@@ -35,6 +35,9 @@ WORKDIR /usr/local/apisix
 
 ENV PATH=$PATH:/usr/local/openresty/luajit/bin:/usr/local/openresty/nginx/sbin:/usr/local/openresty/bin
 
+RUN chgrp -R 0 /usr/local/apisix \
+    && chmod -R g=u /usr/local/apisix
+
 # forward request and error logs to docker log collector
 RUN ln -sf /dev/stdout /usr/local/apisix/logs/access.log \
     && ln -sf /dev/stderr /usr/local/apisix/logs/error.log \

--- a/redhat/Dockerfile
+++ b/redhat/Dockerfile
@@ -37,7 +37,7 @@ ENV PATH=$PATH:/usr/local/openresty/luajit/bin:/usr/local/openresty/nginx/sbin:/
 
 RUN groupadd --system --gid 636 apisix \
     && useradd --system --gid apisix --no-create-home --shell /usr/sbin/nologin --uid 636 apisix \
-    && chown -R apisix:apisix /usr/local/apisix \
+    && chown -R apisix:0 /usr/local/apisix \
     && chgrp -R 0 /usr/local/apisix \
     && chmod -R g=u /usr/local/apisix
 

--- a/redhat/Dockerfile
+++ b/redhat/Dockerfile
@@ -38,7 +38,6 @@ ENV PATH=$PATH:/usr/local/openresty/luajit/bin:/usr/local/openresty/nginx/sbin:/
 RUN groupadd --system --gid 636 apisix \
     && useradd --system --gid apisix --no-create-home --shell /usr/sbin/nologin --uid 636 apisix \
     && chown -R apisix:0 /usr/local/apisix \
-    && chgrp -R 0 /usr/local/apisix \
     && chmod -R g=u /usr/local/apisix
 
 # forward request and error logs to docker log collector

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -53,7 +53,7 @@ ENV PATH=$PATH:/usr/local/openresty/luajit/bin:/usr/local/openresty/nginx/sbin:/
 
 RUN groupadd --system --gid 636 apisix \
     && useradd --system --gid apisix --no-create-home --shell /usr/sbin/nologin --uid 636 apisix \
-    && chown -R apisix:apisix /usr/local/apisix \
+    && chown -R apisix:0 /usr/local/apisix \
     && chgrp -R 0 /usr/local/apisix \
     && chmod -R g=u /usr/local/apisix
 

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -54,7 +54,6 @@ ENV PATH=$PATH:/usr/local/openresty/luajit/bin:/usr/local/openresty/nginx/sbin:/
 RUN groupadd --system --gid 636 apisix \
     && useradd --system --gid apisix --no-create-home --shell /usr/sbin/nologin --uid 636 apisix \
     && chown -R apisix:0 /usr/local/apisix \
-    && chgrp -R 0 /usr/local/apisix \
     && chmod -R g=u /usr/local/apisix
 
 USER apisix

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -53,7 +53,9 @@ ENV PATH=$PATH:/usr/local/openresty/luajit/bin:/usr/local/openresty/nginx/sbin:/
 
 RUN groupadd --system --gid 636 apisix \
     && useradd --system --gid apisix --no-create-home --shell /usr/sbin/nologin --uid 636 apisix \
-    && chown -R apisix:apisix /usr/local/apisix
+    && chown -R apisix:apisix /usr/local/apisix \
+    && chgrp -R 0 /usr/local/apisix \
+    && chmod -R g=u /usr/local/apisix
 
 USER apisix
 


### PR DESCRIPTION
Implemented the OpenShift-without-anyuid permission fix in all relevant Dockerfile variants by making /usr/local/apisix group-owned by GID 0 and aligning group permissions with user permissions.

This was to complete #612 which seemed abandoned.

Dockerfile permissions update:
- Modified the debian, ubuntu and redhat Dockerfiles to recursively change the group ownership of /usr/local/apisix to group 0 and set group permissions to match user permissions.


Fixes apache/apisix#13075
