### PR TITLE
chore: release 3.16.0

### DIFF
--- a/.github/workflows/apisix-docker-example-test-standalone.yaml
+++ b/.github/workflows/apisix-docker-example-test-standalone.yaml
@@ -14,7 +14,7 @@ on:
       - 'release/apisix-2.15.**'
 
 env:
-  APISIX_VERSION: "3.15.0"
+  APISIX_VERSION: "3.16.0"
 
 jobs:
   prepare:

--- a/.github/workflows/apisix-docker-example-test.yaml
+++ b/.github/workflows/apisix-docker-example-test.yaml
@@ -14,7 +14,7 @@ on:
       - 'release/apisix-2.15.**'
 
 env:
-  APISIX_VERSION: "3.15.0"
+  APISIX_VERSION: "3.16.0"
 
 jobs:
   prepare:

--- a/.github/workflows/apisix_push_docker_hub.yaml
+++ b/.github/workflows/apisix_push_docker_hub.yaml
@@ -19,7 +19,7 @@ jobs:
           - debian
           - redhat
     env:
-      APISIX_DOCKER_TAG: 3.15.0-${{ matrix.platform }}
+      APISIX_DOCKER_TAG: 3.16.0-${{ matrix.platform }}
 
     steps:
       - name: Check out the repo

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@ SHELL := bash
 
 
 # APISIX ARGS
-APISIX_VERSION ?= 3.15.0
-MAX_APISIX_VERSION ?= 3.15.0
+APISIX_VERSION ?= 3.16.0
+MAX_APISIX_VERSION ?= 3.16.0
 IMAGE_NAME = apache/apisix
 IMAGE_TAR_NAME = apache_apisix
 APISIX_REPO = https://github.com/apache/apisix

--- a/all-in-one/apisix-dashboard/Dockerfile
+++ b/all-in-one/apisix-dashboard/Dockerfile
@@ -17,7 +17,7 @@
 
 ARG ENABLE_PROXY=false
 ARG ETCD_VERSION=v3.4.14
-ARG APISIX_VERSION=3.15.0
+ARG APISIX_VERSION=3.16.0
 ARG APISIX_DASHBOARD_VERSION=master
 
 # Build Apache APISIX (using official package with apisix-nginx-module)

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -17,7 +17,7 @@
 
 FROM debian:bullseye-slim
 
-ARG APISIX_VERSION=3.15.0
+ARG APISIX_VERSION=3.16.0
 
 RUN set -ex; \
     arch=$(dpkg --print-architecture); \

--- a/docs/en/latest/build.md
+++ b/docs/en/latest/build.md
@@ -43,7 +43,7 @@ Find an APISIX [release version](https://github.com/apache/apisix/releases) to b
 Build a Docker image from the release:
 
 ```shell
-APISIX_VERSION=3.15.0   # specify release version
+APISIX_VERSION=3.16.0   # specify release version
 DISTRO=debian           # debian, redhat
 make build-on-$DISTRO
 ```

--- a/example/docker-compose-arm64.yml
+++ b/example/docker-compose-arm64.yml
@@ -19,7 +19,7 @@ version: "3"
 
 services:
   apisix:
-    image: apache/apisix:3.15.0-debian
+    image: apache/apisix:3.16.0-debian
     restart: always
     volumes:
       - ./apisix_conf/config.yaml:/usr/local/apisix/conf/config.yaml:ro

--- a/example/docker-compose-standalone.yml
+++ b/example/docker-compose-standalone.yml
@@ -19,7 +19,7 @@ version: "3"
 
 services:
   apisix:
-    image: apache/apisix:${APISIX_IMAGE_TAG:-3.15.0-debian}
+    image: apache/apisix:${APISIX_IMAGE_TAG:-3.16.0-debian}
     restart: always
     volumes:
       - ./apisix_conf/apisix-standalone.yaml:/usr/local/apisix/conf/apisix.yaml:ro

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -19,7 +19,7 @@ version: "3"
 
 services:
   apisix:
-    image: apache/apisix:${APISIX_IMAGE_TAG:-3.15.0-debian}
+    image: apache/apisix:${APISIX_IMAGE_TAG:-3.16.0-debian}
     restart: always
     volumes:
       - ./apisix_conf/config.yaml:/usr/local/apisix/conf/config.yaml:ro

--- a/redhat/Dockerfile
+++ b/redhat/Dockerfile
@@ -17,7 +17,7 @@
 
 FROM registry.access.redhat.com/ubi9/ubi:9.6
 
-ARG APISIX_VERSION=3.15.0
+ARG APISIX_VERSION=3.16.0
 LABEL apisix_version="${APISIX_VERSION}"
 COPY ./yum.repos.d/apache-apisix.repo /etc/yum.repos.d/apache-apisix.repo
 COPY ./yum.repos.d/openresty.repo /etc/yum.repos.d/openresty.repo

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -17,7 +17,7 @@
 
 FROM ubuntu:24.04
 
-ARG APISIX_VERSION=3.15.0
+ARG APISIX_VERSION=3.16.0
 
 RUN set -ex; \
     arch=$(dpkg --print-architecture); \


### PR DESCRIPTION
## Summary
- Bump APISIX version from 3.15.0 to 3.16.0 across all Dockerfiles, CI workflows, docker-compose files, Makefile, and documentation.