### PR TITLE
fix(ci): use allowed versions of docker based actions

### DIFF
--- a/.github/workflows/apisix_push_docker_hub.yaml
+++ b/.github/workflows/apisix_push_docker_hub.yaml
@@ -55,14 +55,14 @@ jobs:
           fi
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
 
       - name: Login to Docker Hub
         if: ${{ startsWith(github.ref_name, 'release/apisix') }}
-        uses: docker/login-action@v1
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
Use allowed versions mentioned here: https://github.com/apache/infrastructure-actions/blob/92c5789d0bb7050ecff1612695b4f5f40bc22a01/approved_patterns.yml#L114