### PR TITLE
chore: release 3.17.0

### DIFF
--- a/.github/workflows/apisix-docker-example-test-standalone.yaml
+++ b/.github/workflows/apisix-docker-example-test-standalone.yaml
@@ -14,7 +14,7 @@ on:
       - 'release/apisix-2.15.**'
 
 env:
-  APISIX_VERSION: "3.16.0"
+  APISIX_VERSION: "3.17.0"
 
 jobs:
   prepare:

--- a/.github/workflows/apisix-docker-example-test.yaml
+++ b/.github/workflows/apisix-docker-example-test.yaml
@@ -14,7 +14,7 @@ on:
       - 'release/apisix-2.15.**'
 
 env:
-  APISIX_VERSION: "3.16.0"
+  APISIX_VERSION: "3.17.0"
 
 jobs:
   prepare:

--- a/.github/workflows/apisix_push_docker_hub.yaml
+++ b/.github/workflows/apisix_push_docker_hub.yaml
@@ -19,7 +19,7 @@ jobs:
           - debian
           - redhat
     env:
-      APISIX_DOCKER_TAG: 3.16.0-${{ matrix.platform }}
+      APISIX_DOCKER_TAG: 3.17.0-${{ matrix.platform }}
 
     steps:
       - name: Check out the repo

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@ SHELL := bash
 
 
 # APISIX ARGS
-APISIX_VERSION ?= 3.16.0
-MAX_APISIX_VERSION ?= 3.16.0
+APISIX_VERSION ?= 3.17.0
+MAX_APISIX_VERSION ?= 3.17.0
 IMAGE_NAME = apache/apisix
 IMAGE_TAR_NAME = apache_apisix
 APISIX_REPO = https://github.com/apache/apisix

--- a/all-in-one/apisix-dashboard/Dockerfile
+++ b/all-in-one/apisix-dashboard/Dockerfile
@@ -110,6 +110,7 @@ RUN apt update \
        curl \
        ca-certificates \
        libyaml-0-2 \
+       libpcre3 \
        lua5.1 \
     && rm -rf /var/lib/apt/lists/*
 

--- a/all-in-one/apisix-dashboard/Dockerfile
+++ b/all-in-one/apisix-dashboard/Dockerfile
@@ -21,7 +21,7 @@ ARG APISIX_VERSION=3.17.0
 ARG APISIX_DASHBOARD_VERSION=master
 
 # Build Apache APISIX (using official package with apisix-nginx-module)
-FROM debian:bullseye-slim AS production-stage
+FROM debian:bookworm-slim AS production-stage
 
 ARG APISIX_VERSION
 LABEL apisix_version="${APISIX_VERSION}"
@@ -30,7 +30,7 @@ RUN set -ex; \
     arch=$(dpkg --print-architecture); \
     apt update; \
     apt-get -y install --no-install-recommends wget gnupg ca-certificates curl; \
-    codename=`grep -Po 'VERSION="[0-9]+ \(\K[^)]+' /etc/os-release`; \
+    codename="debian12"; \
     case "${arch}" in \
       amd64) \
         wget -O - https://repos.apiseven.com/pubkey.gpg | apt-key add - \

--- a/all-in-one/apisix-dashboard/Dockerfile
+++ b/all-in-one/apisix-dashboard/Dockerfile
@@ -101,7 +101,7 @@ RUN if [ "$ENABLE_PROXY" = "true" ] ; then yarn config set registry https://regi
     && yarn build
 
 # Finally combine all the resources into one image
-FROM debian:bullseye-slim AS last-stage
+FROM debian:bookworm-slim AS last-stage
 
 # add runtime for Apache APISIX
 RUN apt update \

--- a/all-in-one/apisix-dashboard/Dockerfile
+++ b/all-in-one/apisix-dashboard/Dockerfile
@@ -17,7 +17,7 @@
 
 ARG ENABLE_PROXY=false
 ARG ETCD_VERSION=v3.4.14
-ARG APISIX_VERSION=3.16.0
+ARG APISIX_VERSION=3.17.0
 ARG APISIX_DASHBOARD_VERSION=master
 
 # Build Apache APISIX (using official package with apisix-nginx-module)

--- a/all-in-one/apisix/Dockerfile
+++ b/all-in-one/apisix/Dockerfile
@@ -32,7 +32,7 @@ USER root
 RUN wget https://github.com/etcd-io/etcd/releases/download/${ETCD_VERSION}/etcd-${ETCD_VERSION}-linux-amd64.tar.gz \
     && tar -zxvf etcd-${ETCD_VERSION}-linux-amd64.tar.gz \
     && mv etcd-${ETCD_VERSION}-linux-amd64/* /usr/bin/ \
-    && rm /usr/local/openresty/bin/etcdctl
+    && rm -f /usr/local/openresty/bin/etcdctl
 
 
 WORKDIR /usr/local/apisix

--- a/debian-dev/Dockerfile.local
+++ b/debian-dev/Dockerfile.local
@@ -33,6 +33,8 @@ RUN set -x \
     && apt-get -y update --fix-missing \
     && apt-get install -y \
         make \
+        cmake \
+        g++ \
         git  \
         sudo \
         libyaml-dev \

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -37,7 +37,7 @@ RUN set -ex; \
     apt update \
     && apt install -y apisix=${APISIX_VERSION}-0 \
     && apt-get purge -y --auto-remove \
-    && rm /usr/local/openresty/bin/etcdctl \
+    && rm -f /usr/local/openresty/bin/etcdctl \
     && openresty -V \
     && apisix version
 

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -17,7 +17,7 @@
 
 FROM debian:bookworm-slim
 
-ARG APISIX_VERSION=3.16.0
+ARG APISIX_VERSION=3.17.0
 
 RUN set -ex; \
     arch=$(dpkg --print-architecture); \

--- a/docs/en/latest/build.md
+++ b/docs/en/latest/build.md
@@ -43,7 +43,7 @@ Find an APISIX [release version](https://github.com/apache/apisix/releases) to b
 Build a Docker image from the release:
 
 ```shell
-APISIX_VERSION=3.16.0   # specify release version
+APISIX_VERSION=3.17.0   # specify release version
 DISTRO=debian           # debian, redhat
 make build-on-$DISTRO
 ```

--- a/example/docker-compose-arm64.yml
+++ b/example/docker-compose-arm64.yml
@@ -19,7 +19,7 @@ version: "3"
 
 services:
   apisix:
-    image: apache/apisix:3.16.0-debian
+    image: apache/apisix:3.17.0-debian
     restart: always
     volumes:
       - ./apisix_conf/config.yaml:/usr/local/apisix/conf/config.yaml:ro

--- a/example/docker-compose-standalone.yml
+++ b/example/docker-compose-standalone.yml
@@ -19,7 +19,7 @@ version: "3"
 
 services:
   apisix:
-    image: apache/apisix:${APISIX_IMAGE_TAG:-3.16.0-debian}
+    image: apache/apisix:${APISIX_IMAGE_TAG:-3.17.0-debian}
     restart: always
     volumes:
       - ./apisix_conf/apisix-standalone.yaml:/usr/local/apisix/conf/apisix.yaml:ro

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -19,7 +19,7 @@ version: "3"
 
 services:
   apisix:
-    image: apache/apisix:${APISIX_IMAGE_TAG:-3.16.0-debian}
+    image: apache/apisix:${APISIX_IMAGE_TAG:-3.17.0-debian}
     restart: always
     volumes:
       - ./apisix_conf/config.yaml:/usr/local/apisix/conf/config.yaml:ro

--- a/redhat/Dockerfile
+++ b/redhat/Dockerfile
@@ -17,7 +17,7 @@
 
 FROM registry.access.redhat.com/ubi9/ubi:9.6
 
-ARG APISIX_VERSION=3.16.0
+ARG APISIX_VERSION=3.17.0
 LABEL apisix_version="${APISIX_VERSION}"
 COPY ./yum.repos.d/apache-apisix.repo /etc/yum.repos.d/apache-apisix.repo
 COPY ./yum.repos.d/openresty.repo /etc/yum.repos.d/openresty.repo

--- a/redhat/Dockerfile
+++ b/redhat/Dockerfile
@@ -43,7 +43,7 @@ RUN groupadd --system --gid 636 apisix \
 # forward request and error logs to docker log collector
 RUN ln -sf /dev/stdout /usr/local/apisix/logs/access.log \
     && ln -sf /dev/stderr /usr/local/apisix/logs/error.log \
-    && rm /usr/local/openresty/bin/etcdctl
+    && rm -f /usr/local/openresty/bin/etcdctl
 
 USER apisix
 

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -37,7 +37,7 @@ RUN set -ex; \
     apt update \
     && apt install -y apisix=${APISIX_VERSION}-0 \
     && apt-get purge -y --auto-remove \
-    && rm /usr/local/openresty/bin/etcdctl \
+    && rm -f /usr/local/openresty/bin/etcdctl \
     && openresty -V \
     && apisix version
 

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -17,7 +17,7 @@
 
 FROM ubuntu:24.04
 
-ARG APISIX_VERSION=3.16.0
+ARG APISIX_VERSION=3.17.0
 
 RUN set -ex; \
     arch=$(dpkg --print-architecture); \


### PR DESCRIPTION
Bump APISIX version from 3.16.0 to 3.17.0 across Dockerfiles, Makefile, example compose files, CI workflows, and docs.

https://github.com/apache/apisix/blob/release/3.17/CHANGELOG.md#3170