### PR TITLE
ci: use local httpbin container instead of flaky httpbin.org

### DIFF
--- a/.github/workflows/apisix_dev_push_docker_hub.yaml
+++ b/.github/workflows/apisix_dev_push_docker_hub.yaml
@@ -40,7 +40,7 @@ jobs:
             "upstream": {
                 "type": "roundrobin",
                 "nodes": {
-                    "httpbin.org:80": 1
+                    "httpbin:80": 1
                 }
             }
           }'

--- a/.github/workflows/apisix_push_docker_hub.yaml
+++ b/.github/workflows/apisix_push_docker_hub.yaml
@@ -43,7 +43,7 @@ jobs:
             "upstream": {
                 "type": "roundrobin",
                 "nodes": {
-                    "httpbin.org:80": 1
+                    "httpbin:80": 1
                 }
             }
           }'

--- a/compose/docker-compose-master.yaml
+++ b/compose/docker-compose-master.yaml
@@ -50,6 +50,13 @@ services:
     networks:
       - apisix
 
+  # local upstream for CI route tests, avoids the flaky public httpbin.org
+  httpbin:
+    image: kennethreitz/httpbin
+    restart: always
+    networks:
+      - apisix
+
 networks:
   apisix:
     driver: bridge

--- a/compose/docker-compose-release.yaml
+++ b/compose/docker-compose-release.yaml
@@ -50,6 +50,13 @@ services:
     networks:
       - apisix
 
+  # local upstream for CI route tests, avoids the flaky public httpbin.org
+  httpbin:
+    image: kennethreitz/httpbin
+    restart: always
+    networks:
+      - apisix
+
 networks:
   apisix:
     driver: bridge


### PR DESCRIPTION
### Description

The CI route tests proxy through APISIX to the public `httpbin.org`, which is not very stable. Intermittent `502`/`503` responses cause spurious `result_code: 50x` failures on random platforms, requiring re-runs that aren't related to any code change.

This replaces the external dependency with a local httpbin container (the Postman-maintained [`postmanlabs/httpbin`](https://github.com/postmanlabs/httpbin), published as `kennethreitz/httpbin` and already used in apache/apisix CI), so the route tests resolve `httpbin:80` over the compose network instead of reaching out to the internet.

Changes:
- Add an `httpbin` service to `compose/docker-compose-release.yaml` and `compose/docker-compose-master.yaml` on the existing `apisix` network.
- Point the route upstream in `apisix_push_docker_hub.yaml` and `apisix_dev_push_docker_hub.yaml` at `httpbin:80` instead of `httpbin.org:80`.

### Verification

`docker compose config` validates both compose files. The `kennethreitz/httpbin` container serves `GET /get` with a `200`, matching the route the tests exercise.