### PR TITLE
fix: install libxml2 and libxslt so the saml-auth plugin loads

### DIFF
--- a/.github/workflows/apisix_push_docker_hub.yaml
+++ b/.github/workflows/apisix_push_docker_hub.yaml
@@ -34,7 +34,11 @@ jobs:
 
       - name: Test route
         run: |
-          grep -C 3 '\[error\]' compose/apisix_log/error.log && exit 1
+          # error.log is symlinked to stderr, so check the container logs
+          if docker logs compose-apisix-1 2>&1 | grep -C 3 '\[error\]'; then
+            echo "found errors in apisix startup logs"
+            exit 1
+          fi
 
           curl http://127.0.0.1:9180/apisix/admin/routes/1 \
           -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -35,7 +35,7 @@ RUN set -ex; \
         ;; \
     esac; \
     apt update \
-    && apt install -y apisix=${APISIX_VERSION}-0 \
+    && apt install -y apisix=${APISIX_VERSION}-0 libxml2 libxslt1.1 \
     && apt-get purge -y --auto-remove \
     && rm -f /usr/local/openresty/bin/etcdctl \
     && openresty -V \

--- a/redhat/Dockerfile
+++ b/redhat/Dockerfile
@@ -23,7 +23,7 @@ COPY ./yum.repos.d/apache-apisix.repo /etc/yum.repos.d/apache-apisix.repo
 COPY ./yum.repos.d/openresty.repo /etc/yum.repos.d/openresty.repo
 
 RUN yum update -y \
-	&& yum install -y apisix-${APISIX_VERSION} wget\
+	&& yum install -y apisix-${APISIX_VERSION} wget libxml2 libxslt\
 	&& yum clean all \
 	&& sed -i 's/PASS_MAX_DAYS\t99999/PASS_MAX_DAYS\t60/g' /etc/login.defs
 

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -35,7 +35,7 @@ RUN set -ex; \
         ;; \
     esac; \
     apt update \
-    && apt install -y apisix=${APISIX_VERSION}-0 \
+    && apt install -y apisix=${APISIX_VERSION}-0 libxml2 libxslt1.1 \
     && apt-get purge -y --auto-remove \
     && rm -f /usr/local/openresty/bin/etcdctl \
     && openresty -V \


### PR DESCRIPTION
### What this fixes

The `saml-auth` plugin added in APISIX 3.17.0 (apache/apisix#13346) pulls in the `lua-resty-saml` rock. Its native `saml.so` dynamically links `libxml2.so.2` and `libxslt.so.1`, which are **not installed** in the runtime images. As a result every worker logs this on startup and the plugin cannot be used:

```
[error] load_plugin(): failed to load plugin [saml-auth] err: error loading module 'saml'
from file '/usr/local/apisix/deps/lib/lua/5.1/saml.so':
	libxml2.so.2: cannot open shared object file: No such file or directory
```

Reproduce on the published image:

```
docker run --rm --entrypoint sh apache/apisix:3.17.0-debian \
  -c "ldd /usr/local/apisix/deps/lib/lua/5.1/saml.so"
# libxml2.so.2 => not found
# libxslt.so.1 => not found
```

### Fix

Install `libxml2` + `libxslt1.1` (debian/ubuntu) and `libxml2` + `libxslt` (redhat) as runtime dependencies. After the fix, `ldd` resolves both libraries and APISIX boots with no `saml-auth` load errors.

### Why CI didn't catch it

The `Test route` step checked `compose/apisix_log/error.log`, but that file never exists (the container's `error.log` is symlinked to stderr), so `grep ... && exit 1` always short-circuited and startup errors slipped through green. This PR makes the step grep the container logs instead, so a failing plugin load now fails the build.

### Verification

Built the patched debian image locally and booted it against etcd:

```
ldd .../saml.so   # libxml2.so.2 and libxslt.so.1 both resolved
docker logs <apisix>  # 0 "failed to load plugin [saml-auth]" lines
```