### PR TITLE
Update apisix-grafana-dashboard.json

### DIFF
--- a/example/grafana_conf/dashboards/apisix-grafana-dashboard.json
+++ b/example/grafana_conf/dashboards/apisix-grafana-dashboard.json
@@ -148,7 +148,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(apisix_http_requests_total{instance=~\"$instance\"})",
+          "expr": "sum(apisix_http_requests_total{instance=~\"$instance\",route=~\"$route\"})",
           "intervalFactor": 2,
           "legendFormat": "Total",
           "refId": "A"
@@ -520,7 +520,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(apisix_bandwidth{instance=~\"$instance\"}[30s])) by (type)",
+          "expr": "sum(rate(apisix_bandwidth{instance=~\"$instance\",route=~\"$route\"}[30s])) by (type)",
           "legendFormat": "{{type}}",
           "refId": "A"
         }
@@ -1083,20 +1083,20 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.90, sum(rate(apisix_http_latency_bucket{type=~\"request\",service=~\"$service\",consumer=~\"$consumer\",node=~\"$node\"}[1m])) by (le))",
+          "expr": "histogram_quantile(0.90, sum(rate(apisix_http_latency_bucket{type=~\"request\",service=~\"$service\",route=~\"$route\",consumer=~\"$consumer\",node=~\"$node\"}[1m])) by (le))",
           "format": "time_series",
           "interval": "",
           "legendFormat": "P90",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.95, sum(rate(apisix_http_latency_bucket{type=~\"request\",service=~\"$service\",consumer=~\"$consumer\",node=~\"$node\"}[1m])) by (le))",
+          "expr": "histogram_quantile(0.95, sum(rate(apisix_http_latency_bucket{type=~\"request\",service=~\"$service\",route=~\"$route\",consumer=~\"$consumer\",node=~\"$node\"}[1m])) by (le))",
           "interval": "",
           "legendFormat": "P95",
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(0.99, sum(rate(apisix_http_latency_bucket{type=~\"request\",service=~\"$service\",consumer=~\"$consumer\",node=~\"$node\"}[1m])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(rate(apisix_http_latency_bucket{type=~\"request\",service=~\"$service\",route=~\"$route\",consumer=~\"$consumer\",node=~\"$node\"}[1m])) by (le))",
           "interval": "",
           "legendFormat": "P99",
           "refId": "C"
@@ -1206,7 +1206,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.90, sum(rate(apisix_http_latency_bucket{type=~\"apisix\",service=~\"$service\",consumer=~\"$consumer\",node=~\"$node\"}[1m])) by (le))",
+          "expr": "histogram_quantile(0.90, sum(rate(apisix_http_latency_bucket{type=~\"apisix\",service=~\"$service\",route=~\"$route\",consumer=~\"$consumer\",node=~\"$node\"}[1m])) by (le))",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -1215,13 +1215,13 @@
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.95, sum(rate(apisix_http_latency_bucket{type=~\"apisix\",service=~\"$service\",consumer=~\"$consumer\",node=~\"$node\"}[1m])) by (le))",
+          "expr": "histogram_quantile(0.95, sum(rate(apisix_http_latency_bucket{type=~\"apisix\",service=~\"$service\",route=~\"$route\",consumer=~\"$consumer\",node=~\"$node\"}[1m])) by (le))",
           "interval": "",
           "legendFormat": "P95",
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(0.99, sum(rate(apisix_http_latency_bucket{type=~\"apisix\",service=~\"$service\",consumer=~\"$consumer\",node=~\"$node\"}[1m])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(rate(apisix_http_latency_bucket{type=~\"apisix\",service=~\"$service\",route=~\"$route\",consumer=~\"$consumer\",node=~\"$node\"}[1m])) by (le))",
           "interval": "",
           "legendFormat": "P99",
           "refId": "C"
@@ -1330,20 +1330,20 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.90, sum(rate(apisix_http_latency_bucket{type=~\"upstream\",service=~\"$service\",consumer=~\"$consumer\",node=~\"$node\"}[1m])) by (le))",
+          "expr": "histogram_quantile(0.90, sum(rate(apisix_http_latency_bucket{type=~\"upstream\",service=~\"$service\",route=~\"$route\",consumer=~\"$consumer\",node=~\"$node\"}[1m])) by (le))",
           "format": "time_series",
           "interval": "",
           "legendFormat": "P90",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.95, sum(rate(apisix_http_latency_bucket{type=~\"upstream\",service=~\"$service\",consumer=~\"$consumer\",node=~\"$node\"}[1m])) by (le))",
+          "expr": "histogram_quantile(0.95, sum(rate(apisix_http_latency_bucket{type=~\"upstream\",service=~\"$service\",route=~\"$route\",consumer=~\"$consumer\",node=~\"$node\"}[1m])) by (le))",
           "interval": "",
           "legendFormat": "P95",
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(0.99, sum(rate(apisix_http_latency_bucket{type=~\"upstream\",service=~\"$service\",consumer=~\"$consumer\",node=~\"$node\"}[1m])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(rate(apisix_http_latency_bucket{type=~\"upstream\",service=~\"$service\",route=~\"$route\",consumer=~\"$consumer\",node=~\"$node\"}[1m])) by (le))",
           "interval": "",
           "legendFormat": "P99",
           "refId": "C"


### PR DESCRIPTION
I successfully added the``$route`` filter variable to all 5 panels that could support route filtering. The changes were made to the Grafana dashboard JSON file at:

``apisix-docker-master\example\grafana_conf\dashboards\apisix-grafana-dashboard.json``

Here's what was modified:

1. Total Requests (line 151): Added``route=~\"$route\"`` to the query
2. Bandwidth (line 523): Added``route=~\"$route\"`` to the query
3. Request Latency (lines 1086, 1093, 1099): Added``route=~\"$route\"`` to all 3 queries (P90, P95, P99)
4. APISIX Latency (lines 1209, 1218, 1224): Added``route=~\"$route\"`` to all 3 queries (P90, P95, P99)
5. Upstream Latency (lines 1333, 1340, 1346): Added``route=~\"$route\"`` to all 3 queries (P90, P95, P99)