### PR TITLE
fix: docker entrypoint remove stream_worker_events.sock if exists

### DIFF
--- a/debian-dev/docker-entrypoint.sh
+++ b/debian-dev/docker-entrypoint.sh
@@ -54,6 +54,10 @@ _EOC_
         rm -f "/usr/local/apisix/logs/worker_events.sock"
     fi
 
+    if [ -e "/usr/local/apisix/logs/stream_worker_events.sock" ]; then
+        rm -f "/usr/local/apisix/logs/stream_worker_events.sock"
+    fi
+
     exec /usr/local/openresty/bin/openresty -p /usr/local/apisix -g 'daemon off;'
 fi
 

--- a/redhat/docker-entrypoint.sh
+++ b/redhat/docker-entrypoint.sh
@@ -53,6 +53,10 @@ _EOC_
     if [ -e "/usr/local/apisix/logs/worker_events.sock" ]; then
         rm -f "/usr/local/apisix/logs/worker_events.sock"
     fi
+
+    if [ -e "/usr/local/apisix/logs/stream_worker_events.sock" ]; then
+        rm -f "/usr/local/apisix/logs/stream_worker_events.sock"
+    fi
     
     exec /usr/local/openresty/bin/openresty -p /usr/local/apisix -g 'daemon off;'
 fi

--- a/utils/docker-entrypoint.sh
+++ b/utils/docker-entrypoint.sh
@@ -53,6 +53,10 @@ _EOC_
     if [ -e "/usr/local/apisix/logs/worker_events.sock" ]; then
         rm -f "/usr/local/apisix/logs/worker_events.sock"
     fi
+
+    if [ -e "/usr/local/apisix/logs/stream_worker_events.sock" ]; then
+        rm -f "/usr/local/apisix/logs/stream_worker_events.sock"
+    fi
     
     exec /usr/local/openresty/bin/openresty -p /usr/local/apisix -g 'daemon off;'
 fi


### PR DESCRIPTION
**Why submit this pull request?**

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

apache/apisix#12546 added cleanup of a leftover `stream_worker_events.sock` to `docker/debian-dev/docker-entrypoint.sh` in the `apache/apisix` repo, which only feeds the `apache/apisix:dev` image. The entrypoint scripts in this repo — the ones used by the released `-debian` / `-ubuntu` / `-redhat` / `latest` images — never received it, so no released image has the fix.

With stream proxy enabled, a container that terminates abnormally leaves the socket behind and fails to start again:

```
[emerg] bind() to unix:/usr/local/apisix/logs/stream_worker_events.sock failed (98: Address already in use)
[emerg] still could not bind()
```

This applies the same 4-line cleanup to all three entrypoint copies: `utils/` (debian, ubuntu, debian-dev builds), `redhat/` (excluded from the `cp ./utils/*.sh` step), and `debian-dev/` (used by `build-on-debian-local-dev`).

Verified by building `apache/apisix:3.17.0-debian` locally and repeating SIGKILL + restart with `proxy_mode: http&stream`: fails before the change, starts cleanly after.

**Related issues**

fix apache/apisix#13752

**Checklist:**

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [x] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first
