### PR TITLE
fix(ci): use an allowlisted docker/login-action pin

### DIFF
--- a/.github/workflows/apisix_push_docker_hub.yaml
+++ b/.github/workflows/apisix_push_docker_hub.yaml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Login to Docker Hub
         if: ${{ startsWith(github.ref_name, 'release/apisix') }}
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
**Why submit this pull request?**

- [x] Bugfix

**What changes will this PR take into?**

The Docker image workflow has been dead since 2026-07-11 — every run ends in `startup_failure` before a single job is created, so it never even shows up as a failing check. `docker/login-action@b45d80f8` (v4.0.0) was dropped from the ASF approved actions list, and the run annotation says:

> The action docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 is not allowed in apache/apisix-docker because all actions must be from a repository owned by your enterprise, created by GitHub, or match one of the patterns: ...

`approved_patterns.yml` now only lists v4.1.0 through v4.6.0 for `login-action`, so this bumps the pin to v4.6.0 (`dbcb813823bdd20940b903addbd779551569679f`). The `setup-qemu-action` and `setup-buildx-action` pins are still on the list and are left alone.

Runs affected so far: the `release/apisix-3.17.0` push for #627, and both the PR run and the master push for #629. Because the release branch build never started, `apache/apisix:3.17.0-*` and `latest` on Docker Hub are still the 2026-06-18 build and do not contain the libxml2/libxslt fix from #627 — the images need a rebuild once this lands.

Same class of breakage as #619, just a different action that aged out of the allowlist.

**Related issues**

N/A

**Checklist:**

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [x] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first
